### PR TITLE
react-schema-renderer readme&readme.zh-cn Form/FormItem component demo bug fix

### DIFF
--- a/packages/react-schema-renderer/README.md
+++ b/packages/react-schema-renderer/README.md
@@ -278,7 +278,7 @@ import { Form } from 'antd'
 
 export const CompatFormComponent = ({children,...props})=>{
   return <Form {...props}>{children}</Form> //Very simple to use the Form component, props is the props of the SchemaForm component, here will be directly transparent
-})
+}
 
 export const CompatFormItemComponent = ({children,...props})=>{
   const messages = [].concat(props.errors || [], props.warnings || [])
@@ -317,6 +317,7 @@ export default ()=>{
        formComponent={CompatFormComponent}
        formItemComponent={CompatFormItemComponent}
     />
+  )
 }
 
 ```

--- a/packages/react-schema-renderer/README.zh-cn.md
+++ b/packages/react-schema-renderer/README.zh-cn.md
@@ -274,7 +274,7 @@ import { Form } from 'antd'
 
 export const CompatFormComponent = ({children,...props})=>{
   return <Form {...props}>{children}</Form> //很简单的使用Form组件，props是SchemaForm组件的props，这里会直接透传
-})
+}
 
 export const CompatFormItemComponent = ({children,...props})=>{
   const messages = [].concat(props.errors || [], props.warnings || [])
@@ -313,6 +313,7 @@ export default ()=>{
        formComponent={CompatFormComponent}
        formItemComponent={CompatFormItemComponent}
     />
+  )
 }
 
 ```


### PR DESCRIPTION
[react-schema-renderer文档](https://github.com/alibaba/formily/blob/master/packages/react-schema-renderer/README.zh-cn.md#%E5%A6%82%E4%BD%95%E6%8E%A5%E5%85%A5-formformitem-%E7%BB%84%E4%BB%B6) 例子跑不起来，修改了下。
- CompatFormComponent函数多了个）结尾
- 单例注册方式那行少了个）结尾
