### PR TITLE
React schema editor 优化

### DIFF
--- a/packages/react-schema-editor/package.json
+++ b/packages/react-schema-editor/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@ant-design/compatible": "^0.0.1-rc.1",
+    "@ant-design/icons": "^4.0.3",
     "@formily/antd": "^1.0.9",
     "antd": "^4.0",
     "lodash": "^4.17.15"

--- a/packages/react-schema-editor/src/index.tsx
+++ b/packages/react-schema-editor/src/index.tsx
@@ -48,7 +48,11 @@ export const SchemaEditor: React.FC<{
   }
 
   const handleSchemaChange = (schema: string) => {
-    onChange(JSON.parse(schema))
+    try {
+      onChange(JSON.parse(schema))
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   const isRoot = selectedPath === 'root'


### PR DESCRIPTION
react-schema-editor使用中的问题

1. package依赖中没申明@ant-design/icons，导致直接启动报错。

2. 源码编辑的时候，编辑代码不符合json格式直接页面挂掉。