### PR TITLE
修复default、visible、display、required、rules不支持表达式

### DIFF
--- a/packages/react-schema-renderer/src/__tests__/display.spec.tsx
+++ b/packages/react-schema-renderer/src/__tests__/display.spec.tsx
@@ -139,3 +139,46 @@ test('display is false will not validate(include children)', async () => {
   expect(onValidateFailedHandler).toHaveBeenCalledTimes(0)
 })
 
+test('display is expression true will display react node', async () => {
+  const TestComponent = () => {
+    const schema = {
+      'type': 'object',
+      'properties': {
+        'aa': {
+          'x-component': 'string',
+          'title': 'aa',
+          'default':'123321',
+          'display':'{{true}}'
+        },
+      }
+    }
+    return (
+      <SchemaForm schema={schema}/>
+    )
+  }
+  const { queryByText } = render(<TestComponent />)
+  await wait()
+  expect(queryByText('123321')).toBeVisible()
+})
+
+test('display is expression false will hide react node', async () => {
+  const TestComponent = () => {
+    const schema = {
+      'type': 'object',
+      'properties': {
+        'aa': {
+          'x-component': 'string',
+          'title': 'aa',
+          'default':'123321',
+          'display':'{{false}}'
+        },
+      }
+    }
+    return (
+      <SchemaForm schema={schema}/>
+    )
+  }
+  const { queryByText } = render(<TestComponent />)
+  await wait()
+  expect(queryByText('123321')).toBeNull()
+})

--- a/packages/react-schema-renderer/src/__tests__/validate.spec.tsx
+++ b/packages/react-schema-renderer/src/__tests__/validate.spec.tsx
@@ -517,3 +517,53 @@ test('async validate side effect', async () => {
   await wait()
   expect(queryAllByText('This field is required').length).toEqual(1)
 })
+
+test('required support expression', async () => {
+  const handleSubmit = jest.fn()
+  const handleValidateFailed = jest.fn()
+  const TestComponent = () => (
+    <SchemaForm onSubmit={handleSubmit} onValidateFailed={handleValidateFailed}>
+      <Fragment>
+        <Field name="text" type="string" required="{{true}}" />
+        <button type="submit" data-testid="btn">
+          Submit
+        </button>
+      </Fragment>
+    </SchemaForm>
+  )
+
+  const { getByTestId, getByText } = render(<TestComponent />)
+
+  fireEvent.click(getByTestId('btn'))
+  await wait()
+  fireEvent.click(getByTestId('btn'))
+  await wait()
+  expect(handleSubmit).toHaveBeenCalledTimes(0)
+  expect(handleValidateFailed).toHaveBeenCalledTimes(2)
+  expect(getByText('This field is required')).toBeVisible()
+})
+
+test('rules support expression', async () => {
+  const handleSubmit = jest.fn()
+  const handleValidateFailed = jest.fn()
+  const TestComponent = () => (
+    <SchemaForm onSubmit={handleSubmit} onValidateFailed={handleValidateFailed}>
+      <Fragment>
+        <Field name="text" type="string" x-rules={{ required: "{{true}}"}} />
+        <button type="submit" data-testid="btn">
+          Submit
+        </button>
+      </Fragment>
+    </SchemaForm>
+  )
+
+  const { getByTestId, getByText } = render(<TestComponent />)
+
+  fireEvent.click(getByTestId('btn'))
+  await wait()
+  fireEvent.click(getByTestId('btn'))
+  await wait()
+  expect(handleSubmit).toHaveBeenCalledTimes(0)
+  expect(handleValidateFailed).toHaveBeenCalledTimes(2)
+  expect(getByText('This field is required')).toBeVisible()
+})

--- a/packages/react-schema-renderer/src/__tests__/value.spec.tsx
+++ b/packages/react-schema-renderer/src/__tests__/value.spec.tsx
@@ -383,3 +383,24 @@ test('remove initial value by onFieldChange', async () => {
 
   expect(queryAllByTestId('test-input')[0].getAttribute('value')).toEqual('')
 })
+
+test('default value support expression', async () => {
+  const TestComponent = () => {
+    const schema = {
+      'type': 'object',
+      'properties': {
+        'aa': {
+          'x-component': 'string',
+          'default':'{{123321}}',
+        },
+      }
+    }
+    return (
+      <SchemaForm schema={schema}/>
+    )
+  }
+  const { getByTestId } = render(<TestComponent />)
+  await wait()
+  expect(getByTestId('test-input').getAttribute('value')).toEqual('123321')
+})
+

--- a/packages/react-schema-renderer/src/__tests__/visible.spec.tsx
+++ b/packages/react-schema-renderer/src/__tests__/visible.spec.tsx
@@ -178,3 +178,47 @@ test('visible is false will not validate(include children)', async () => {
     bb: '123'
   })
 })
+
+test('visible is expression true will show react node', async () => {
+  const TestComponent = () => {
+    const schema = {
+      'type': 'object',
+      'properties': {
+        'aa': {
+          'x-component': 'string',
+          'title': 'aa',
+          'default':'123321',
+          'visible':'{{true}}'
+        },
+      }
+    }
+    return (
+      <SchemaForm schema={schema}/>
+    )
+  }
+  const { queryByText } = render(<TestComponent />)
+  await wait()
+  expect(queryByText('123321')).toBeVisible()
+})
+
+test('visible is expression false will remove react node', async () => {
+  const TestComponent = () => {
+    const schema = {
+      'type': 'object',
+      'properties': {
+        'aa': {
+          'x-component': 'string',
+          'title': 'aa',
+          'default':'123321',
+          'visible':'{{false}}'
+        },
+      }
+    }
+    return (
+      <SchemaForm schema={schema}/>
+    )
+  }
+  const { queryByText } = render(<TestComponent />)
+  await wait()
+  expect(queryByText('123321')).toBeNull()
+})

--- a/packages/react-schema-renderer/src/components/SchemaField.tsx
+++ b/packages/react-schema-renderer/src/components/SchemaField.tsx
@@ -76,8 +76,14 @@ export const SchemaField: React.FunctionComponent<ISchemaFieldProps> = (
         dataType={fieldSchema.type}
         triggerType={fieldSchema.getExtendsTriggerType()}
         editable={fieldSchema.getExtendsEditable()}
-        visible={fieldSchema.getExtendsVisible()}
-        display={fieldSchema.getExtendsDisplay()}
+        visible={complieExpression(
+          fieldSchema.getExtendsVisible(),
+          expressionScope
+        )}
+        display={complieExpression(
+          fieldSchema.getExtendsDisplay(),
+          expressionScope
+        )}
         required={fieldSchema.getExtendsRequired()}
         rules={fieldSchema.getExtendsRules()}
         computeState={computeSchemaState}

--- a/packages/react-schema-renderer/src/components/SchemaField.tsx
+++ b/packages/react-schema-renderer/src/components/SchemaField.tsx
@@ -64,7 +64,10 @@ export const SchemaField: React.FunctionComponent<ISchemaFieldProps> = (
     return (
       <Field
         path={path}
-        initialValue={fieldSchema.default}
+        initialValue={complieExpression(
+          fieldSchema.default,
+          expressionScope
+        )}
         props={complieExpression(
           fieldSchema.getSelfProps(),
           expressionScope,

--- a/packages/react-schema-renderer/src/components/SchemaField.tsx
+++ b/packages/react-schema-renderer/src/components/SchemaField.tsx
@@ -84,8 +84,14 @@ export const SchemaField: React.FunctionComponent<ISchemaFieldProps> = (
           fieldSchema.getExtendsDisplay(),
           expressionScope
         )}
-        required={fieldSchema.getExtendsRequired()}
-        rules={fieldSchema.getExtendsRules()}
+        required={complieExpression(
+          fieldSchema.getExtendsRequired(),
+          expressionScope
+        )}
+        rules={complieExpression(
+          fieldSchema.getExtendsRules(),
+          expressionScope
+        )}
         computeState={computeSchemaState}
       >
         {({ state, mutators, form }) => {

--- a/packages/react-schema-renderer/src/types.ts
+++ b/packages/react-schema-renderer/src/types.ts
@@ -117,7 +117,7 @@ export interface ISchema {
   uniqueItems?: boolean
   maxProperties?: number
   minProperties?: number
-  required?: string[] | boolean
+  required?: string[] | boolean | string
   format?: string
   /** nested json schema spec **/
   properties?: {
@@ -131,8 +131,8 @@ export interface ISchema {
   additionalProperties?: ISchema
   /** extend json schema specs */
   editable?: boolean
-  visible?: boolean
-  display?: boolean
+  visible?: boolean | string
+  display?: boolean | string
   triggerType?: 'onBlur' | 'onChange'
   ['x-props']?: { [name: string]: any }
   ['x-index']?: number


### PR DESCRIPTION
schema模式的时候default、visible、display、required、rules增加表达式支持。

增加对应的单元测试。
ISchema  typescript类型修改，统一增加string类型。

复现地址 [https://codesandbox.io/s/upbeat-swanson-x9oqv](https://codesandbox.io/s/upbeat-swanson-x9oqv)