### PR TITLE
fix: JSX Schema模块下FormItem在不可编辑时对label required处理问题修复

### DIFF
--- a/packages/antd/src/adaptor/FormItem.tsx
+++ b/packages/antd/src/adaptor/FormItem.tsx
@@ -97,11 +97,11 @@ export const AntdSchemaFieldAdaptor: React.FC<ISchemaFieldAdaptorProps> = props 
       prefixCls={prefixCls}
       label={label}
       labelAlign={labelAlign}
-      required={props.editable === false ? undefined : props.required}
       help={help}
       validateStatus={status}
       extra={extra ? <p>{extra}</p> : undefined}
       {...mergedProps}
+      required={props.editable === false ? undefined : props.required}
       labelCol={label ? normalizeCol(labelCol || contextLabelCol) : undefined}
       wrapperCol={
         label ? normalizeCol(wrapperCol || contextWrapperCol) : undefined

--- a/packages/next/src/adaptor/FormItem.tsx
+++ b/packages/next/src/adaptor/FormItem.tsx
@@ -99,12 +99,12 @@ export const NextSchemaFieldAdaptor: React.FC<ISchemaFieldAdaptorProps> = props 
       label={label}
       labelTextAlign={labelTextAlign}
       labelAlign={labelAlign || 'left'}
-      required={props.editable === false ? undefined : props.required}
       size={size}
       help={help}
       validateState={status}
       extra={<p>{extra}</p>}
       {...mergedProps}
+      required={props.editable === false ? undefined : props.required}
       labelCol={label ? normalizeCol(labelCol || contextLabelCol) : undefined}
       wrapperCol={
         label ? normalizeCol(wrapperCol || contextWrapperCol) : undefined


### PR DESCRIPTION
mergedProps中包含了required字段，因此需要把实际的required赋值放到{...mergedProps}之后才行，否则会被覆盖