### PR TITLE
fix(react-schema-editor): improve SchemaEditor types

### DIFF
--- a/packages/react-schema-editor/src/index.tsx
+++ b/packages/react-schema-editor/src/index.tsx
@@ -18,9 +18,9 @@ import './index.css'
 export const SchemaEditor: React.FC<{
   className?: string
   schema: any
-  showAntdComponents: boolean
-  showFusionComponents: boolean
-  customComponents: []
+  showAntdComponents?: boolean
+  showFusionComponents?: boolean
+  customComponents?: []
   onChange: (schema: any) => void
 }> = ({
   className,


### PR DESCRIPTION
修改 `SchemaEditor` 组件属性 `showAntdComponents`， `showFusionComponents`，`customComponents` 的 TypeScript 类型定义为可选。