### PR TITLE
fix(antd-components): Add default export for the antd

### DIFF
--- a/packages/antd-components/src/switch/index.tsx
+++ b/packages/antd-components/src/switch/index.tsx
@@ -6,3 +6,5 @@ export const Switch = connect({
   valueName: 'checked',
   getProps: mapStyledProps
 })(acceptEnum(AntdSwitch))
+
+export default Switch;


### PR DESCRIPTION
修复 antd-components 的 `Switch` 组件缺少 default export