### PR TITLE
fix: FormTab components 

### DIFF
--- a/docs/zh-cn/schema-develop/form-layout.md
+++ b/docs/zh-cn/schema-develop/form-layout.md
@@ -548,7 +548,7 @@ const App = () => (
       actions={actions}
       onSubmit={v => console.log(v)}
     >
-      <FormTab name="tabs">
+      <FormTab name="tabs" defaultActiveKey={'tab-2'}>
         <FormTab.TabPane name="tab-1" tab="选项1">
           <Field
             type="string"

--- a/packages/antd-components/README.zh-cn.md
+++ b/packages/antd-components/README.zh-cn.md
@@ -2211,7 +2211,7 @@ const App = () => (
       actions={actions}
       onSubmit={v => console.log(v)}
     >
-      <FormTab name="tabs">
+      <FormTab name="tabs" defaultActiveKey={'tab-2'}>
         <FormTab.TabPane name="tab-1" tab="选项1">
           <Field
             type="string"

--- a/packages/antd-components/src/form-tab/index.tsx
+++ b/packages/antd-components/src/form-tab/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from 'react'
+import React, { Fragment, useEffect, useRef } from 'react'
 import {
   createControllerBox,
   ISchemaVirtualFieldComponentProps,
@@ -47,9 +47,11 @@ const parseTabItems = (items: any, hiddenKeys?: string[]) => {
   }, [])
 }
 
-const parseDefaultActiveKey = (props: any, items: any) => {
-  const { defaultActiveKey } = props
-  return defaultActiveKey ? defaultActiveKey : items[0] && items[0].key
+const parseDefaultActiveKey = (hiddenKeys: Array<string> = [], items: any, defaultActiveKey) => {
+  if(!hiddenKeys.includes(defaultActiveKey))return defaultActiveKey
+
+  const index = items.findIndex(item => !hiddenKeys.includes(item.key))
+  return index >= 0 ? items[index].key : ''
 }
 
 const parseChildrenErrors = (errors: any, target: string) => {
@@ -91,15 +93,16 @@ export const FormTab: React.FC<IVirtualBoxProps<IFormTab>> &
   'tab',
   ({ form, schema, name, path }: ISchemaVirtualFieldComponentProps) => {
     const orderProperties = schema.getOrderProperties()
-    let { hiddenKeys, ...componentProps } = schema.getExtendsComponentProps()
+    let { hiddenKeys, defaultActiveKey, ...componentProps } = schema.getExtendsComponentProps()
     hiddenKeys = hiddenKeys || []
     const [{ activeKey, childrenErrors }, setFieldState] = useFieldState<
       ExtendsState
     >({
-      activeKey: parseDefaultActiveKey(schema, orderProperties),
+      activeKey: parseDefaultActiveKey(hiddenKeys, orderProperties, defaultActiveKey),
       childrenErrors: []
     })
-    const items = parseTabItems(orderProperties, hiddenKeys)
+    const itemsRef = useRef([])
+    itemsRef.current = parseTabItems(orderProperties, hiddenKeys)
     const update = (cur: string) => {
       form.notify(StateMap.ON_FORM_TAB_ACTIVE_KEY_CHANGE, {
         name,
@@ -111,9 +114,7 @@ export const FormTab: React.FC<IVirtualBoxProps<IFormTab>> &
     useEffect(() => {
       if (Array.isArray(hiddenKeys)) {
         setFieldState({
-          activeKey: hiddenKeys.includes(activeKey)
-            ? items[0] && items[0].key
-            : activeKey
+          activeKey: parseDefaultActiveKey(hiddenKeys, orderProperties, defaultActiveKey)
         })
       }
     }, [hiddenKeys.length])
@@ -128,6 +129,7 @@ export const FormTab: React.FC<IVirtualBoxProps<IFormTab>> &
       })
       EffectHooks.onTabActiveKeyChange$().subscribe(
         ({ value, name, path }: any = {}) => {
+          if(!itemsRef.current.map(item => item.key).includes(value))return
           matchUpdate(name, path, () => {
             setFieldState({
               activeKey: value
@@ -138,7 +140,7 @@ export const FormTab: React.FC<IVirtualBoxProps<IFormTab>> &
     })
     return (
       <Tabs {...componentProps} activeKey={activeKey} onChange={update}>
-        {items.map(({ props, schema, key }) => {
+        {itemsRef.current.map(({ props, schema, key }) => {
           const currentPath = FormPath.parse(path).concat(key)
           return (
             <Tabs.TabPane

--- a/packages/next-components/README.zh-cn.md
+++ b/packages/next-components/README.zh-cn.md
@@ -2195,7 +2195,7 @@ const App = () => (
       actions={actions}
       onSubmit={v => console.log(v)}
     >
-      <FormTab name="tabs">
+      <FormTab name="tabs" defaultActiveKey={'tab-2'}>
         <FormTab.TabPane name="tab-1" tab="选项1">
           <Field
             type="string"


### PR DESCRIPTION
1. 修复语法错误：两个逗号
2. 设置activeKey之前做检查，如果activeKey不存在则不设置
3. 解析默认activeKey时检查defaultActiveKey是否被隐藏，如果被隐藏则不设置
4. 同步antd-components中的FormTab 修改