### PR TITLE
fix(antd): fix ie.tsx ssr bug

### DIFF
--- a/packages/antd/src/components/FormMegaLayout/ie.tsx
+++ b/packages/antd/src/components/FormMegaLayout/ie.tsx
@@ -1,4 +1,6 @@
-const isIECompat = !('grid-column-gap' in document?.documentElement?.style)
+import { globalThisPolyfill } from '@formily/shared'
+
+const isIECompat = !('grid-column-gap' in globalThisPolyfill?.document?.documentElement?.style)
 const getIEGridContainerStyle = (opts) => {
     if (isIECompat) {
         const { gutter, autoRow } = opts

--- a/packages/next/src/components/FormMegaLayout/ie.tsx
+++ b/packages/next/src/components/FormMegaLayout/ie.tsx
@@ -1,4 +1,6 @@
-const isIECompat = !('grid-column-gap' in document?.documentElement?.style)
+import { globalThisPolyfill } from '@formily/shared'
+
+const isIECompat = !('grid-column-gap' in globalThisPolyfill?.document?.documentElement?.style)
 const getIEGridContainerStyle = (opts) => {
     if (isIECompat) {
         const { gutter, autoRow } = opts


### PR DESCRIPTION
fix(antd): fix ie.tsx SSR bug

In ie.tsx, there is a line would break server side rendering, like below:

`const isIECompat = !('grid-column-gap' in document?.documentElement?.style)`

It will cause this error during SSR:

```
ReferenceError: document is not defined
    at Object.<anonymous> (..../et_operation_platform/node_modules/@formily/antd-components/node_modules/@formily/antd/lib/components/FormMegaLayout/ie.js:4:48)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Module.require (internal/modules/cjs/loader.js:849:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (..../et_operation_platform/node_modules/@formily/antd-components/node_modules/@formily/antd/lib/components/FormMegaLayout/style.js:17:12)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Module.require (internal/modules/cjs/loader.js:849:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (..../et_operation_platform/node_modules/@formily/antd-components/node_modules/@formily/antd/lib/components/FormMegaLayout/index.js:46:15)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Module.require (internal/modules/cjs/loader.js:849:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (..../et_operation_platform/node_modules/@formily/antd-components/node_modules/@formily/antd/lib/components/FormItem.js:40:15)
```

So, we must validate if document exists first.

Hope it would be a quick merge process because this bug is quite annoying that let SSR completely fail.

