### PR TITLE
fix: 回滚mutators.move行为

### DIFF
--- a/packages/core/src/externals.ts
+++ b/packages/core/src/externals.ts
@@ -1064,7 +1064,7 @@ export const createFormExternals = (
       shift() {
         return mutators.remove(0)
       },
-      swap() {
+      swap($from: number, $to: number) {
         const arr = toArr(getValue()).slice()
         const fromItem = arr[$from]
         const toItem = arr[$to]

--- a/packages/core/src/externals.ts
+++ b/packages/core/src/externals.ts
@@ -1064,12 +1064,20 @@ export const createFormExternals = (
       shift() {
         return mutators.remove(0)
       },
-      move($from: number, $to: number) {
+      swap() {
         const arr = toArr(getValue()).slice()
         const fromItem = arr[$from]
         const toItem = arr[$to]
         arr[$from] = toItem
         arr[$to] = fromItem
+        setValue(arr)
+        return arr
+      },
+      move($from: number, $to: number) {
+        const arr = toArr(getValue()).slice()
+        const item = arr[$from]
+        arr.splice($from, 1)
+        arr.splice($to, 0, item)
         setValue(arr)
         return arr
       },


### PR DESCRIPTION
原本`mutators.move`对数据的操作是“迁移”，将`fromIndex`移动到`toIndex`之后。但是之前一个版本变成了“交换”，将`fromIndex`与`toIndex`互换

回滚原先的`mutators.move`行为，并添加`mutators.swap`方法提供“交换”的能力