### PR TITLE
fix(shared): update cool-path version, ensure bug to be fixed

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "camel-case": "~3.0.0",
-    "cool-path": "^0.1.23",
+    "cool-path": "^0.1.31",
     "lower-case": "~1.1.4",
     "scheduler": "~0.19.0",
     "upper-case": "~1.1.3"


### PR DESCRIPTION
更新依赖的`cool-path`到最新版本，以确保使用了`package-lock.json`锁定依赖版本的用户，在更新了最新的formily包后，能正常使用