### PR TITLE
fix(core): fix concat proxy

### DIFF
--- a/packages/core/src/models/field.ts
+++ b/packages/core/src/models/field.ts
@@ -201,8 +201,8 @@ export const Field = createModel<IFieldState, IFieldStateProps>(
       if (dirtys.ruleWarnings) {
         draft.ruleWarnings = normalizeMessages(draft.ruleWarnings)
       }
-      draft.errors = draft.ruleErrors.concat(draft.effectErrors)
-      draft.warnings = draft.ruleWarnings.concat(draft.effectWarnings)
+      draft.errors = [...draft.ruleErrors, ...draft.effectErrors]
+      draft.warnings = [...draft.warnings, ...draft.warnings]
     }
 
     produceEditable(draft: Draft<IFieldState>, dirtys: FieldStateDirtyMap) {

--- a/packages/core/src/models/field.ts
+++ b/packages/core/src/models/field.ts
@@ -202,7 +202,7 @@ export const Field = createModel<IFieldState, IFieldStateProps>(
         draft.ruleWarnings = normalizeMessages(draft.ruleWarnings)
       }
       draft.errors = [...draft.ruleErrors, ...draft.effectErrors]
-      draft.warnings = [...draft.warnings, ...draft.warnings]
+      draft.warnings = [...draft.ruleWarnings, ...draft.effectWarnings]
     }
 
     produceEditable(draft: Draft<IFieldState>, dirtys: FieldStateDirtyMap) {


### PR DESCRIPTION
### 背景

参考：https://github.com/alibaba/formily/issues/759

Array.prototype.concat，如果参数被【识别】为数组，则取其中的元素添加；否则作为一个整体

- 原生的识别机制不确定，视环境而定
- 通过Array.isArray，是可以识别Proxy的；例如lodash就是这么做的

### 测试代码

参考：https://github.com/tvcutsem/harmony-reflect/issues/19

```
var a = ['x', 'y'];
var h = {};
var aProxy = new Proxy(a, h);
var aConcat = [].concat(a);
var aProxyConcat = [].concat(aProxy);

console.log(aConcat.length, aProxyConcat.length)
```

无法识别Proxy为数组的：

- Node.js 11.12.0，输出：2 1
- Safari 11.0，输出：2 1

能够识别Proxy为数组的：

- Chrome 85.0.4183.83，输出：2 2
- Safari 13.0.5，输出：2 2

### 如何检测

- 临时在进行Proxy的地方加上__isProxy标识

```
// 例如：immer/src/core/proxy.ts

const objectTraps: ProxyHandler<ProxyState> = {
    get(state, prop) {
+       if (prop === '__isProxy') return true;
```

- 拦截所有concat调用

```
var oldConcat = Array.prototype.concat;
Array.prototype.concat = function(...args) {
    args.forEach(x => {
        if (Array.isArray(x) && x.__isProxy) debugger
    })
    return oldConcat.apply(this, args)
}
```

### 结论

所幸，formily里面只发现了这一个地方需要修改。

示例：
```
setFieldState(path, state => {
  state.errors = []
})
```

影响：Proxy之后的空数组无法被正确concat，导致校验误判

```
fieldState.errors = [[]]
fieldState.errors.length > 0
fieldState.valid = false
```