### PR TITLE
fix(antd-components): missing 'key' prop warning when table draggable

### DIFF
--- a/packages/antd-components/src/array-table/index.tsx
+++ b/packages/antd-components/src/array-table/index.tsx
@@ -137,6 +137,7 @@ export const ArrayTable: any = styled(
     if (draggable) {
       columns.unshift({
         width: 20,
+        key: 'dragHandler',
         render: () => {
           return <DragHandler className="drag-handler" />
         }


### PR DESCRIPTION
修复使用 ArrayTable 且开启 draggable 时，报警告的问题 Each child in a list should have a unique "key" prop. in TableCell (created by TableRow)。

*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, add tests!
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).
5. Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.