### PR TITLE
preview 文本如果包含换行符，换行展示

### DIFF
--- a/packages/react-shared-components/src/PreviewText.tsx
+++ b/packages/react-shared-components/src/PreviewText.tsx
@@ -43,6 +43,12 @@ export const PreviewText: React.FC<IPreviewTextProps> & {
       value = String(
         props.value === undefined || props.value === null ? '' : props.value
       )
+      // 如果有换行符，拆分成多行
+      if (value.match('\n')) {
+        value = value
+          .split('\n')
+          .map((subStr, index) => <div key={index}>{subStr}</div>)
+      }
     }
   }
   const placeholder = isFn(context.previewPlaceholder)


### PR DESCRIPTION
feat: preview-wrap

表单只读字段展示时，如果值是string且包含换行符\n, 则换行显示