### PR TITLE
feat: add registerPreviewTextComponent

### DIFF
--- a/packages/antd/README.zh-cn.md
+++ b/packages/antd/README.zh-cn.md
@@ -1667,6 +1667,43 @@ const App = () => {
 ReactDOM.render(<App />, document.getElementById('root'))
 ```
 
+#### registerPreviewTextComponent
+
+全局扩展 `<PreviewText/>` UI 组件
+
+```typescript
+function registerPreviewTextComponent(
+  component: React.JSXElementConstructor<any>
+)
+```
+
+**用法**
+
+```jsx
+import React from 'react'
+import ReactDOM from 'react-dom'
+import {
+  SchemaForm,
+  SchemaMarkupField as Field,
+  registerPreviewTextComponent
+} from '@formily/antd'
+import { Input } from '@formily/antd-components'
+
+registerPreviewTextComponent(props => {
+  return <div>**自定义PreviewText**</div>
+})
+
+const App = () => {
+  return (
+    <SchemaForm components={{ Input }} editable={false}>
+      <Field type="string" name="name" title="Name" x-component="Input" />
+    </SchemaForm>
+  )
+}
+
+ReactDOM.render(<App />, document.getElementById('root'))
+```
+
 #### registerFormField
 
 ```typescript

--- a/packages/antd/src/shared.ts
+++ b/packages/antd/src/shared.ts
@@ -2,7 +2,8 @@ import React from 'react'
 import { PreviewText } from '@formily/react-shared-components'
 import {
   IConnectProps,
-  MergedFieldComponentProps
+  MergedFieldComponentProps,
+  getRegistry
 } from '@formily/react-schema-renderer'
 import { version } from 'antd'
 import { each } from '@formily/shared'
@@ -38,7 +39,7 @@ export const mapTextComponent = (
   const { editable } = fieldProps
   if (editable !== undefined) {
     if (editable === false) {
-      return PreviewText
+      return getRegistry().previewText || PreviewText
     }
   }
   return Target

--- a/packages/next/README.zh-cn.md
+++ b/packages/next/README.zh-cn.md
@@ -1729,6 +1729,43 @@ const App = () => {
 ReactDOM.render(<App />, document.getElementById('root'))
 ```
 
+#### registerPreviewTextComponent
+
+全局扩展 `<PreviewText/>` UI 组件
+
+```typescript
+function registerPreviewTextComponent(
+  component: React.JSXElementConstructor<any>
+)
+```
+
+**用法**
+
+```jsx
+import React from 'react'
+import ReactDOM from 'react-dom'
+import {
+  SchemaForm,
+  SchemaMarkupField as Field,
+  registerPreviewTextComponent
+} from '@formily/next'
+import { Input } from '@formily/next-components'
+
+registerPreviewTextComponent(props => {
+  return <div>**自定义PreviewText**</div>
+})
+
+const App = () => {
+  return (
+    <SchemaForm components={{ Input }} editable={false}>
+      <Field type="string" name="name" title="Name" x-component="Input" />
+    </SchemaForm>
+  )
+}
+
+ReactDOM.render(<App />, document.getElementById('root'))
+```
+
 #### registerFormField
 
 ```typescript

--- a/packages/next/src/shared.ts
+++ b/packages/next/src/shared.ts
@@ -2,7 +2,8 @@ import React from 'react'
 import { PreviewText } from '@formily/react-shared-components'
 import {
   MergedFieldComponentProps,
-  IConnectProps
+  IConnectProps,
+  getRegistry
 } from '@formily/react-schema-renderer'
 import { each } from '@formily/shared'
 export * from '@formily/shared'
@@ -96,7 +97,7 @@ export const mapTextComponent = (
   const { editable } = fieldProps
   if (editable !== undefined) {
     if (editable === false) {
-      return PreviewText
+      return getRegistry().previewText || PreviewText
     }
   }
   return Target

--- a/packages/react-schema-renderer/src/shared/registry.ts
+++ b/packages/react-schema-renderer/src/shared/registry.ts
@@ -14,7 +14,8 @@ const registry: ISchemaFormRegistry = {
   virtualFields: {},
   wrappers: [],
   formItemComponent: ({ children }) => children,
-  formComponent: 'form'
+  formComponent: 'form',
+  previewText: null
 }
 
 export const getRegistry = () => {
@@ -22,7 +23,8 @@ export const getRegistry = () => {
     fields: registry.fields,
     virtualFields: registry.virtualFields,
     formItemComponent: registry.formItemComponent,
-    formComponent: registry.formComponent
+    formComponent: registry.formComponent,
+    previewText: registry.previewText
   }
 }
 
@@ -30,6 +32,7 @@ export const cleanRegistry = () => {
   registry.fields = {}
   registry.virtualFields = {}
   registry.wrappers = []
+  registry.previewText = null
 }
 
 export function registerFormComponent<Props = any>(
@@ -130,3 +133,11 @@ export const registerFieldMiddleware = deprecate<
     }
   )
 })
+
+export function registerPreviewTextComponent<Props = any>(
+  component: React.JSXElementConstructor<Props>
+) {
+  if (isFn(component)) {
+    registry.previewText = component
+  }
+}

--- a/packages/react-schema-renderer/src/types.ts
+++ b/packages/react-schema-renderer/src/types.ts
@@ -97,6 +97,7 @@ export interface ISchemaFormRegistry {
   wrappers?: ISchemaFieldWrapper[]
   formItemComponent: React.JSXElementConstructor<any>
   formComponent: string | React.JSXElementConstructor<any>
+  previewText?: React.JSXElementConstructor<any>
 }
 
 export type SchemaMessage = React.ReactNode


### PR DESCRIPTION
增加自定义 `PreviewText` 组件的注册能力，用于全局替换默认的 `PreviewText` 实现