### PR TITLE
fix: 修改FormButtonGroup api描述(#1134)

### DIFF
--- a/packages/antd/README.zh-cn.md
+++ b/packages/antd/README.zh-cn.md
@@ -522,7 +522,7 @@ ReactDOM.render(<App />, document.getElementById('root'))
 | sticky          | 是否吸附在页面底部 | boolean                                                                            |        |
 | itemStyle       | 每个 Btn 的样式    | React.CSSProperties                                                                |        |
 | align           | 对齐方式           | 'left' `or` 'right' `or` 'start' `or` 'end' `or` 'top' `or` 'bottom' `or` 'center' |        |
-| triggerDistance | 按钮间距离         | number                                                                             |        |
+| triggerDistance | 按钮吸底的偏移量，sticky 为 true 时生效 | number                                                                             |        |
 | zIndex          | z-index            | number                                                                             |        |
 | span            | 跨列配置           | number                                                                             | string |  |
 | offset          | 偏移配置           | number                                                                             | string |  |

--- a/packages/next/README.zh-cn.md
+++ b/packages/next/README.zh-cn.md
@@ -588,7 +588,7 @@ ReactDOM.render(<App />, document.getElementById('root'))
 | sticky          | 是否吸附在页面底部 | boolean                                                                            |        |
 | itemStyle       | 每个 Btn 的样式    | React.CSSProperties                                                                |        |
 | align           | 对齐方式           | 'left' `or` 'right' `or` 'start' `or` 'end' `or` 'top' `or` 'bottom' `or` 'center' |        |
-| triggerDistance | 按钮间距离         | number                                                                             |        |
+| triggerDistance | 按钮吸底的偏移量，sticky 为 true 时生效 | number                                                                             |        |
 | zIndex          | z-index            | number                                                                             |        |
 | span            | 跨列配置           | number                                                                             | string |  |
 | offset          | 偏移配置           | number                                                                             | string |  |


### PR DESCRIPTION
修复 #1134 提到的问题。triggerDistance 不生效的实际原因是用途描述错误，根据代码，triggerDistance 应该表示按钮吸底距离。