### PR TITLE
feat: applicable to vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@testing-library/react": "^11.2.3",
     "@testing-library/vue": "^5.6.1",
     "@types/hoist-non-react-statics": "^3.3.1",
+    "@types/fs-extra": "^9.0.9",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.6.8",
     "@types/react": "^17.0.0",

--- a/packages/antd/copy.ts
+++ b/packages/antd/copy.ts
@@ -1,12 +1,61 @@
-import { copy } from 'fs-extra'
+import { copy, readFile, writeFile } from 'fs-extra'
 import glob from 'glob'
 
-glob(`./src/**/*.{less,scss}`, (err, files) => {
-  if (err) {
-    throw err
-  }
-  files.forEach((filename) => {
-    copy(filename, filename.replace(/src\//, 'esm/'))
-    copy(filename, filename.replace(/src\//, 'lib/'))
+const copyStyle = () =>
+  new Promise((resolve, reject) => {
+    glob(`./src/**/*.{less,scss}`, (err, files) => {
+      if (err) {
+        return reject(err)
+      }
+
+      return Promise.all(
+        files.reduce(
+          (reproduces, filename) => [
+            ...reproduces,
+            copy(filename, filename.replace(/src\//, 'esm/')),
+            copy(filename, filename.replace(/src\//, 'lib/')),
+          ],
+          [] as Promise<void>[]
+        )
+      )
+        .then(resolve)
+        .catch(reject)
+    })
   })
-})
+
+const esStr = 'antd/es/'
+const libStr = 'antd/lib/'
+
+const replaceLibWithEsRegExp = (flags?: 'g' | 'i' | 'm' | 'u' | 'y') =>
+  new RegExp(libStr, flags)
+
+const replaceLibWithEs = () =>
+  new Promise((resolve, reject) => {
+    glob(`./esm/**/style.js`, (err, files) => {
+      if (err) {
+        return reject(err)
+      }
+
+      const replaceOperation = async (filename: string) => {
+        const fileContent: string = (await readFile(filename)).toString()
+
+        if (!replaceLibWithEsRegExp().test(fileContent)) {
+          return Promise.resolve()
+        }
+
+        return writeFile(
+          filename,
+          fileContent.replace(replaceLibWithEsRegExp('g'), esStr)
+        )
+      }
+
+      return Promise.all(files.map((filename) => replaceOperation(filename)))
+        .then(resolve)
+        .catch(reject)
+    })
+  })
+
+;(async () => {
+  await copyStyle()
+  await replaceLibWithEs()
+})()

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "start": "dumi dev",
     "build": "rimraf -rf lib && npm run build:cjs && npm run build:esm && npm run copy:style",
-    "copy:style": "ts-node copy",
+    "copy:style": "cross-env INIT_RUN=true ts-node copy",
     "build:cjs": "tsc --declaration",
     "build:esm": "tsc --declaration --module es2015 --outDir esm",
     "build:docs": "dumi build"

--- a/packages/next/copy.ts
+++ b/packages/next/copy.ts
@@ -1,12 +1,61 @@
-import { copy } from 'fs-extra'
+import { copy, readFile, writeFile } from 'fs-extra'
 import glob from 'glob'
 
-glob(`./src/**/*.{less,scss}`, (err, files) => {
-  if (err) {
-    throw err
-  }
-  files.forEach((filename) => {
-    copy(filename, filename.replace(/src\//, 'esm/'))
-    copy(filename, filename.replace(/src\//, 'lib/'))
+const copyStyle = () =>
+  new Promise((resolve, reject) => {
+    glob(`./src/**/*.{less,scss}`, (err, files) => {
+      if (err) {
+        return reject(err)
+      }
+
+      return Promise.all(
+        files.reduce(
+          (reproduces, filename) => [
+            ...reproduces,
+            copy(filename, filename.replace(/src\//, 'esm/')),
+            copy(filename, filename.replace(/src\//, 'lib/')),
+          ],
+          [] as Promise<void>[]
+        )
+      )
+        .then(resolve)
+        .catch(reject)
+    })
   })
-})
+
+const esStr = '@alifd/next/es/'
+const libStr = '@alifd/next/lib/'
+
+const replaceLibWithEsRegExp = (flags?: 'g' | 'i' | 'm' | 'u' | 'y') =>
+  new RegExp(libStr, flags)
+
+const replaceLibWithEs = () =>
+  new Promise((resolve, reject) => {
+    glob(`./esm/**/style.js`, (err, files) => {
+      if (err) {
+        return reject(err)
+      }
+
+      const replaceOperation = async (filename: string) => {
+        const fileContent: string = (await readFile(filename)).toString()
+
+        if (!replaceLibWithEsRegExp().test(fileContent)) {
+          return Promise.resolve()
+        }
+
+        return writeFile(
+          filename,
+          fileContent.replace(replaceLibWithEsRegExp('g'), esStr)
+        )
+      }
+
+      return Promise.all(files.map((filename) => replaceOperation(filename)))
+        .then(resolve)
+        .catch(reject)
+    })
+  })
+
+;(async () => {
+  await copyStyle()
+  await replaceLibWithEs()
+})()

--- a/packages/next/copy.ts
+++ b/packages/next/copy.ts
@@ -1,61 +1,6 @@
-import { copy, readFile, writeFile } from 'fs-extra'
-import glob from 'glob'
+import { runCopy } from '../antd/copy'
 
-const copyStyle = () =>
-  new Promise((resolve, reject) => {
-    glob(`./src/**/*.{less,scss}`, (err, files) => {
-      if (err) {
-        return reject(err)
-      }
-
-      return Promise.all(
-        files.reduce(
-          (reproduces, filename) => [
-            ...reproduces,
-            copy(filename, filename.replace(/src\//, 'esm/')),
-            copy(filename, filename.replace(/src\//, 'lib/')),
-          ],
-          [] as Promise<void>[]
-        )
-      )
-        .then(resolve)
-        .catch(reject)
-    })
-  })
-
-const esStr = '@alifd/next/es/'
-const libStr = '@alifd/next/lib/'
-
-const replaceLibWithEsRegExp = (flags?: 'g' | 'i' | 'm' | 'u' | 'y') =>
-  new RegExp(libStr, flags)
-
-const replaceLibWithEs = () =>
-  new Promise((resolve, reject) => {
-    glob(`./esm/**/style.js`, (err, files) => {
-      if (err) {
-        return reject(err)
-      }
-
-      const replaceOperation = async (filename: string) => {
-        const fileContent: string = (await readFile(filename)).toString()
-
-        if (!replaceLibWithEsRegExp().test(fileContent)) {
-          return Promise.resolve()
-        }
-
-        return writeFile(
-          filename,
-          fileContent.replace(replaceLibWithEsRegExp('g'), esStr)
-        )
-      }
-
-      return Promise.all(files.map((filename) => replaceOperation(filename)))
-        .then(resolve)
-        .catch(reject)
-    })
-  })
-
-;(async () => {
-  await copyStyle()
-  await replaceLibWithEs()
-})()
+runCopy({
+  esStr: '@alifd/next/es/',
+  libStr: '@alifd/next/lib/',
+})

--- a/packages/react/src/shared/render.ts
+++ b/packages/react/src/shared/render.ts
@@ -1,4 +1,5 @@
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { globalThisPolyfill } from '@formily/shared'
 
 const env = {
@@ -9,7 +10,7 @@ export const render = (element: React.ReactElement) => {
   if (globalThisPolyfill['document']) {
     env.portalDOM =
       env.portalDOM || globalThisPolyfill['document'].createElement('div')
-    return require('react-dom').createPortal(element, env.portalDOM)
+    return createPortal(element, env.portalDOM)
   } else {
     return React.createElement('template', {}, element)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,6 +2834,13 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/fs-extra@^9.0.9":
+  version "9.0.9"
+  resolved "https://registry.npm.taobao.org/@types/fs-extra/download/@types/fs-extra-9.0.9.tgz#11ed43b3f3c6b3490f1ef9bd17f58da896e2d861"
+  integrity sha1-Ee1Ds/PGs0kPHvm9F/WNqJbi2GE=
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"


### PR DESCRIPTION
调整代码中直接使用 `require` 跟 ` antd/next` 的 `lib` 产物的处理，使 `formily` 可以适用于 `vite`、`snowpack`