### PR TITLE
fix(vue): fix a type error in ISchemaMarkupFieldProps

### DIFF
--- a/packages/vue/src/types/index.ts
+++ b/packages/vue/src/types/index.ts
@@ -109,7 +109,7 @@ export type ISchemaMarkupFieldProps<
     Formily.Core.Types.FormPatternTypes,
     Formily.Core.Types.FieldDisplayTypes,
     Formily.Core.Types.FieldValidator,
-    React.ReactNode,
+    string,
     Formily.Core.Types.GeneralField
   >
 


### PR DESCRIPTION
修复一处遗漏的类型错误