### PR TITLE
refactor(json-schema): refactor stringify type to fix literal type is erased

### DIFF
--- a/packages/json-schema/src/types.ts
+++ b/packages/json-schema/src/types.ts
@@ -129,7 +129,10 @@ export interface ISchemaTransformerOptions extends ISchemaFieldFactoryOptions {
 }
 
 export type Stringify<P extends { [key: string]: any }> = {
-  [key in keyof P]?: P[key] | string
+  /**
+   * Use `string & {}` instead of string to keep Literal Type for ISchema#component and ISchema#decorator
+   */
+  [key in keyof P]?: P[key] | (string & {})
 }
 
 export type ISchema<


### PR DESCRIPTION


*Before* submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

---

## 解决的问题

SchemaField 中的 component 跟 decorator 属性类型被 stringify 抹掉了。

## 修复之前的效果

![image](https://user-images.githubusercontent.com/21048878/119540806-6e7d2d80-bdc0-11eb-9834-eb059dc5bfc0.png)


## 修复之后效果

![image](https://user-images.githubusercontent.com/21048878/119540433-062e4c00-bdc0-11eb-8802-768779731df9.png)
