### PR TITLE
build: fix build global may be failed

### DIFF
--- a/scripts/build-global.ts
+++ b/scripts/build-global.ts
@@ -1,10 +1,9 @@
 import fs from 'fs-extra'
-const copy = (dist = 'esm') => {
-  fs.copy('./src/global.d.ts', `./${dist}/global.d.ts`)
+const copy = async (dist = 'esm') => {
+  await fs.copy('./src/global.d.ts', `./${dist}/global.d.ts`)
 }
-fs.copy('./src/global.d.ts', './lib/global.d.ts')
-const writeRef = (dist = 'esm') => {
-  fs.writeFile(
+const writeRef = async (dist = 'esm') => {
+  await fs.writeFile(
     `./${dist}/index.d.ts`,
     `/// <reference path="global.d.ts" />\n${fs.readFileSync(
       `./${dist}/index.d.ts`,
@@ -12,7 +11,10 @@ const writeRef = (dist = 'esm') => {
     )}`
   )
 }
-copy('esm')
-copy('lib')
-writeRef('esm')
-writeRef('lib')
+
+;(async () => {
+  await copy('esm')
+  await copy('lib')
+  await writeRef('esm')
+  await writeRef('lib')
+})()


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
在 `node v16.0.0 ` 上执行 `yarn build` 发生错误:

```node
 @formily/reactive@2.0.0-beta.76 build:global
> ts-node ../../scripts/build-global

info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run build stderr:

src/index.ts → dist/formily.reactive.umd.development.js...
(node:10388) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at C:\Users\liuwei\Desktop\github\formily\node_modules\rollup-plugin-typescript2\node_modules\tslib\package.json.
Update this package.json to use a subpath pattern like "./*".
(Use `node --trace-deprecation ...` to show where the warning was created)
(!) Circular dependency
src\internals.ts -> src\handlers.ts -> src\internals.ts
created dist/formily.reactive.umd.development.js in 5s

src/index.ts → dist/formily.reactive.umd.production.js...
(!) Circular dependency
src\internals.ts -> src\handlers.ts -> src\internals.ts
created dist/formily.reactive.umd.production.js in 4.4s
Error: EBUSY: resource busy or locked, copyfile 'C:\Users\liuwei\Desktop\github\formily\packages\reactive\src\global.d.ts' -> 'C:\Users\liuwei\Desktop\github\formily\packages\reactive\lib\global.d.ts'
error Command failed with exit code 1.
lerna ERR! yarn run build exited 1 in '@formily/reactive'
lerna WARN complete Waiting for 1 child process to exit. CTRL-C to exit immediately.
error Command failed with exit code 1.
```