### PR TITLE
feat(designable-antd): add ValidatorSetter

### DIFF
--- a/designable/antd/src/components/DesignableField/index.tsx
+++ b/designable/antd/src/components/DesignableField/index.tsx
@@ -11,7 +11,11 @@ import {
   Schema,
   ISchema,
 } from '@formily/react'
-import { DataSourceSetter, ReactionsSetter } from '@formily/designable-setters'
+import {
+  DataSourceSetter,
+  ReactionsSetter,
+  ValidatorSetter,
+} from '@formily/designable-setters'
 import { FormTab } from '@formily/antd'
 import { clone } from '@formily/shared'
 import { FormItemSwitcher } from '../FormItemSwitcher'
@@ -181,9 +185,8 @@ export const createDesignableField = (options: IDesignableFieldProps) => {
           'x-component': DataSourceSetter,
           'x-index': 6,
         },
-        'x-validator': {
-          'x-decorator': 'FormItem',
-          // 'x-component': 'ValidatorSetter',
+        'x-validator-wrapper': {
+          'x-component': ValidatorSetter,
           'x-index': 8,
         },
         required: {

--- a/designable/antd/src/locales/en-US.ts
+++ b/designable/antd/src/locales/en-US.ts
@@ -357,7 +357,7 @@ const FieldLocale = {
     title: 'UI Pattern',
     dataSource: ['Editable', 'Disabled', 'ReadOnly', 'ReadPretty', 'Inherit'],
   },
-  'x-validator': 'Validator',
+  'x-validator-wrapper': 'Validator',
   'x-reactions': 'Reactions',
   'x-decorator': 'Decorator',
   'x-decorator-props': {

--- a/designable/antd/src/locales/zh-CN.ts
+++ b/designable/antd/src/locales/zh-CN.ts
@@ -350,7 +350,7 @@ const FieldLocale = {
     title: 'UI形态',
     dataSource: ['可编辑', '禁用', '只读', '阅读', '继承'],
   },
-  'x-validator': '校验规则',
+  'x-validator-wrapper': '校验规则',
   'x-reactions': '响应器规则',
   'x-decorator': '启用容器组件',
   'x-decorator-props': {

--- a/designable/setters/src/components/ValidatorSetter/ValidatorInput.tsx
+++ b/designable/setters/src/components/ValidatorSetter/ValidatorInput.tsx
@@ -1,0 +1,61 @@
+import { TextWidget } from '@designable/react'
+import {
+  createPolyInput,
+  IInput,
+} from '@designable/react-settings-form/esm/components/PolyInput'
+import { Button, Select } from 'antd'
+import React from 'react'
+import { buildInRules } from './shared'
+
+const isText = (value: any) => {
+  return typeof value === 'string'
+}
+
+const isObject = (value: any) => {
+  return typeof value === 'object'
+}
+
+export const ValidatorInput = ({ onEditRuleClick, ...props }) => {
+  const PolyInput = createPolyInput([
+    {
+      type: 'String',
+      icon: 'Text',
+      toInputValue: (val) => (val === undefined ? 'number' : val),
+      toChangeValue: (val) => (val === undefined ? 'number' : val),
+      component: (props: any) => {
+        if (isObject(props.value)) {
+          return null
+        }
+        return (
+          <Select
+            {...props}
+            align="center"
+            options={buildInRules.map((d) => ({ label: d, value: d }))}
+          />
+        )
+      },
+      checker: isText,
+    },
+    {
+      type: 'Object',
+      icon: 'Code',
+      toInputValue: (val) => (val === undefined ? {} : val),
+      toChangeValue: (val) => (val === undefined ? {} : val),
+      component: () => {
+        return (
+          <Button
+            block
+            onClick={() => {
+              onEditRuleClick(props.value, props.onChange)
+            }}
+          >
+            <TextWidget token="SettingComponents.ValidatorSetter.edit" />
+          </Button>
+        )
+      },
+      checker: isObject,
+    },
+  ])
+
+  return PolyInput(props as IInput)
+}

--- a/designable/setters/src/components/ValidatorSetter/ValidatorList.tsx
+++ b/designable/setters/src/components/ValidatorSetter/ValidatorList.tsx
@@ -1,0 +1,59 @@
+import { usePrefix } from '@designable/react'
+import { ArrayItems, FormItem, Space } from '@formily/antd'
+import { createSchemaField, useField } from '@formily/react'
+import { observer } from '@formily/reactive-react'
+import React, { Fragment } from 'react'
+import './styles.less'
+import { ValidatorInput } from './ValidatorInput'
+
+export interface IValidatorListProps {
+  onEditRuleClick(v, selectedValidatorChangeHandler): void
+}
+
+export const ValidatorList: React.FC<IValidatorListProps> = observer(
+  (props) => {
+    const { onEditRuleClick } = props
+
+    const field = useField()
+    const prefix = usePrefix('validator-setter')
+
+    const SchemaField = createSchemaField({
+      components: {
+        ArrayItems,
+        Space,
+        FormItem,
+        ValidatorInput,
+      },
+    })
+
+    return (
+      <Fragment>
+        <div className={`${prefix + '-content'}`}>
+          <SchemaField basePath={field.address.parent()}>
+            <SchemaField.Array
+              name="x-validator"
+              title="validators"
+              x-component="ArrayItems"
+            >
+              <SchemaField.Void x-component="Space">
+                <SchemaField.Void x-component="ArrayItems.SortHandle" />
+                <SchemaField.Markup
+                  required
+                  name="input"
+                  x-component="ValidatorInput"
+                  x-component-props={{ onEditRuleClick }}
+                />
+                <SchemaField.Void x-component="ArrayItems.Remove" />
+              </SchemaField.Void>
+              <SchemaField.Void
+                x-component="ArrayItems.Addition"
+                title="Add Rule"
+                x-component-props={{ defaultValue: 'number' }}
+              />
+            </SchemaField.Array>
+          </SchemaField>
+        </div>
+      </Fragment>
+    )
+  }
+)

--- a/designable/setters/src/components/ValidatorSetter/ValidatorModal.tsx
+++ b/designable/setters/src/components/ValidatorSetter/ValidatorModal.tsx
@@ -1,0 +1,209 @@
+import { TextWidget, usePrefix } from '@designable/react'
+import { MonacoInput } from '@designable/react-settings-form'
+import {
+  ArrayItems,
+  Form,
+  FormItem,
+  Input,
+  Select,
+  Space,
+  Switch,
+} from '@formily/antd'
+import { createForm } from '@formily/core'
+import { createSchemaField } from '@formily/react'
+import { observer } from '@formily/reactive-react'
+import type { IValidatorRules } from '@formily/validator'
+import { Modal } from 'antd'
+import React, { Fragment, useMemo } from 'react'
+import { buildInRules } from './shared'
+import './styles.less'
+import { IValidatorInfo } from './types'
+import { toJS } from '@formily/reactive'
+
+const SchemaField = createSchemaField({
+  components: {
+    MonacoInput,
+    FormItem,
+    Input,
+    Select,
+    Switch,
+    ArrayItems,
+    Space,
+  },
+})
+
+const numberFields = [
+  'len',
+  'max',
+  'min',
+  'maximum',
+  'minimum',
+  'exclusiveMaximum',
+  'exclusiveMinimum',
+]
+
+export interface IValidatorModalProps {
+  visible?: boolean
+  closeModal?(): void
+  className?: string
+  style?: React.CSSProperties
+  onChange: (v) => void
+  validatorInfo: IValidatorInfo
+}
+
+export const ValidatorModal: React.FC<IValidatorModalProps> = observer(
+  (props) => {
+    const { visible, closeModal, validatorInfo } = props
+
+    const prefix = usePrefix('validator-setter')
+
+    const form = useMemo(() => {
+      const selectedValidator = validatorInfo.selectedValidator
+
+      return createForm({
+        values:
+          typeof selectedValidator === 'object'
+            ? (selectedValidator as IValidatorRules)
+            : {},
+      })
+    }, [validatorInfo.selectedValidator])
+
+    return (
+      <Fragment>
+        <Modal
+          className={`${prefix}-modal`}
+          width={'65%'}
+          style={{ top: 30 }}
+          title={<TextWidget token="SettingComponents.ValidatorSetter.edit" />}
+          bodyStyle={{ padding: 10 }}
+          transitionName=""
+          maskTransitionName=""
+          visible={visible}
+          onCancel={closeModal}
+          onOk={() => {
+            const values = toJS(form.values)
+
+            if (values?.enum?.length === 0) {
+              delete values.enum
+            }
+
+            for (const [k, v] of Object.entries(values)) {
+              if (v === '') {
+                delete values[k]
+              }
+            }
+
+            validatorInfo.selectedValidatorChangeHandler(values)
+            closeModal()
+          }}
+        >
+          <div className={`${prefix}-modal--form-wrapper`}>
+            <div className={`${prefix}-modal--form`}>
+              <Form form={form} labelWidth={150} wrapperWidth={400}>
+                <SchemaField>
+                  <SchemaField.String
+                    name="triggerType"
+                    title="triggerType"
+                    x-decorator="FormItem"
+                    x-component="Select"
+                    enum={[
+                      { label: 'onInput', value: 'onInput' },
+                      { label: 'onFocus', value: 'onFocus' },
+                      { label: 'onBlur', value: 'onBlur' },
+                    ]}
+                  />
+                  <SchemaField.String
+                    name="required"
+                    title="required"
+                    x-decorator="FormItem"
+                    x-component="Switch"
+                  />
+                  <SchemaField.String
+                    name="format"
+                    title="format"
+                    x-decorator="FormItem"
+                    x-component="Select"
+                    enum={['', ...buildInRules].map((d) => ({
+                      label: d,
+                      value: d,
+                    }))}
+                  />
+                  <SchemaField.String
+                    name="validator"
+                    title="validator"
+                    // currently not support
+                    // default="{{(value) => {}}}"
+                    x-decorator="FormItem"
+                    x-component="MonacoInput"
+                    x-component-props={{
+                      width: '100%',
+                      height: 200,
+                      language: 'typescript',
+                    }}
+                  />
+                  <SchemaField.String
+                    name="pattern"
+                    title="pattern"
+                    x-decorator="FormItem"
+                    x-component="Input"
+                  />
+                  {numberFields.map((d, i) => (
+                    <SchemaField.Number
+                      key={i}
+                      name={d}
+                      title={d}
+                      x-decorator="FormItem"
+                      x-component="Input"
+                      x-validator={'number'}
+                    />
+                  ))}
+                  <SchemaField.String
+                    name="whitespace"
+                    title="whitespace"
+                    x-decorator="FormItem"
+                    x-component="Switch"
+                  />
+                  <SchemaField.Array
+                    name="enum"
+                    title="enum"
+                    x-decorator="FormItem"
+                    x-component="ArrayItems"
+                  >
+                    <SchemaField.Void x-component="Space">
+                      <SchemaField.Void
+                        x-decorator="FormItem"
+                        x-component="ArrayItems.SortHandle"
+                      />
+                      <SchemaField.String
+                        x-decorator="FormItem"
+                        required
+                        name="input"
+                        x-component="Input"
+                      />
+                      <SchemaField.Void
+                        x-decorator="FormItem"
+                        x-component="ArrayItems.Remove"
+                      />
+                    </SchemaField.Void>
+                    <SchemaField.Void
+                      x-component="ArrayItems.Addition"
+                      title={
+                        <TextWidget token="SettingComponents.ValidatorSetter.addEnum" />
+                      }
+                    />
+                  </SchemaField.Array>
+                  <SchemaField.String
+                    name="message"
+                    title="message"
+                    x-decorator="FormItem"
+                    x-component="Input"
+                  />
+                </SchemaField>
+              </Form>
+            </div>
+          </div>
+        </Modal>
+      </Fragment>
+    )
+  }
+)

--- a/designable/setters/src/components/ValidatorSetter/index.tsx
+++ b/designable/setters/src/components/ValidatorSetter/index.tsx
@@ -1,0 +1,68 @@
+import { usePrefix } from '@designable/react'
+import { FoldItem } from '@designable/react-settings-form/esm/components/FoldItem'
+import { useField } from '@formily/react'
+import { observer } from '@formily/reactive-react'
+import cls from 'classnames'
+import React, { Fragment, useMemo, useState } from 'react'
+import './styles.less'
+import { IValidatorInfo } from './types'
+import { ValidatorList } from './ValidatorList'
+import { ValidatorModal } from './ValidatorModal'
+
+export interface IValidatorSetterProps {
+  className?: string
+  style?: React.CSSProperties
+}
+
+export const ValidatorSetter: React.FC<IValidatorSetterProps> = observer(
+  (props) => {
+    const { className, style } = props
+
+    const validatorInfo = useMemo<IValidatorInfo>(
+      () => ({
+        selectedValidator: undefined,
+        selectedValidatorChangeHandler() {},
+      }),
+      []
+    )
+
+    const [modalVisible, setModalVisible] = useState(false)
+
+    const openModal = () => setModalVisible(true)
+    const closeModal = () => setModalVisible(false)
+
+    const field = useField()
+    const prefix = usePrefix('validator-setter')
+
+    return (
+      <Fragment>
+        <FoldItem
+          className={cls(prefix, className)}
+          style={style}
+          label={field.title}
+        >
+          <FoldItem.Base></FoldItem.Base>
+          <FoldItem.Extra>
+            <ValidatorList
+              onEditRuleClick={(v, selectedValidatorChangeHandler) => {
+                validatorInfo.selectedValidator = v
+                validatorInfo.selectedValidatorChangeHandler =
+                  selectedValidatorChangeHandler
+                openModal()
+              }}
+            ></ValidatorList>
+          </FoldItem.Extra>
+        </FoldItem>
+
+        <ValidatorModal
+          onChange={(v) => {
+            validatorInfo.selectedValidatorChangeHandler(v)
+          }}
+          validatorInfo={validatorInfo}
+          visible={modalVisible}
+          closeModal={closeModal}
+        ></ValidatorModal>
+      </Fragment>
+    )
+  }
+)

--- a/designable/setters/src/components/ValidatorSetter/shared.ts
+++ b/designable/setters/src/components/ValidatorSetter/shared.ts
@@ -1,0 +1,15 @@
+export const buildInRules = [
+  'url',
+  'email',
+  'ipv6',
+  'ipv4',
+  'number',
+  'integer',
+  'idcard',
+  'qq',
+  'phone',
+  'money',
+  'zh',
+  'date',
+  'zip',
+]

--- a/designable/setters/src/components/ValidatorSetter/styles.less
+++ b/designable/setters/src/components/ValidatorSetter/styles.less
@@ -1,0 +1,34 @@
+@import '~antd/lib/style/themes/default.less';
+
+.dn-validator-setter {
+  &-content {
+    width: 100%;
+    .ant-formily-array-items-item-inner {
+      .ant-space {
+        display: flex;
+        .ant-space-item:nth-child(2) {
+          flex-grow: 1;
+        }
+      }
+    }
+  }
+  &-modal {
+    &--form {
+      margin: 0 auto;
+      width: max-content;
+      &-wrapper {
+        min-height: 400px;
+        max-height: calc(100vh - 240px);
+        overflow: auto;
+      }
+    }
+    .ant-formily-array-items-item-inner {
+      .ant-space {
+        display: flex;
+        .ant-space-item:nth-child(2) {
+          flex-grow: 1;
+        }
+      }
+    }
+  }
+}

--- a/designable/setters/src/components/ValidatorSetter/types.ts
+++ b/designable/setters/src/components/ValidatorSetter/types.ts
@@ -1,0 +1,8 @@
+import type { IValidatorRules, ValidatorFormats } from '@formily/validator'
+
+export type Validator = IValidatorRules | ValidatorFormats
+
+export interface IValidatorInfo {
+  selectedValidator: Validator
+  selectedValidatorChangeHandler(v): void
+}

--- a/designable/setters/src/components/index.ts
+++ b/designable/setters/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './DataSourceSetter'
 export * from './ReactionsSetter'
+export * from './ValidatorSetter'

--- a/designable/setters/src/locales/en-US.ts
+++ b/designable/setters/src/locales/en-US.ts
@@ -46,6 +46,10 @@ export default {
         pleaseSelect: 'Please Select',
         expressionValueTypeIs: 'Expression value type is',
       },
+      ValidatorSetter: {
+        addEnum: 'Add',
+        edit: 'Edit Rule',
+      },
     },
   },
 }

--- a/designable/setters/src/locales/zh-CN.ts
+++ b/designable/setters/src/locales/zh-CN.ts
@@ -44,6 +44,10 @@ export default {
         pleaseSelect: '请选择',
         expressionValueTypeIs: '表达式值类型为',
       },
+      ValidatorSetter: {
+        addEnum: '添加',
+        edit: '编辑规则',
+      },
     },
   },
 }


### PR DESCRIPTION
现在有人已经开始做属性配置的校验规则的可视化设置了么？我打算这个六日尝试实现一下根据 https://core.formilyjs.org/api/models/field#fieldvalidator ，实现下面草图这种功能：

1. 支持添加多个规则；
2. 添加的规则初始是内置模式显示下拉选择器支持选择内置的规则（phone, email 等）；
3. 切换为对象模式时展示编辑按钮，点击后弹出模态框填写对象类型的规则。

![image](https://user-images.githubusercontent.com/25266120/125153085-1473d400-e184-11eb-8d2c-cc3f450b9e69.png)


_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
