### PR TITLE
fix(path): fix segments match

### DIFF
--- a/packages/path/src/__tests__/match.spec.ts
+++ b/packages/path/src/__tests__/match.spec.ts
@@ -116,6 +116,11 @@ test('test group', () => {
   expect(node.match('phases.0.steps.1.type')).toBeTruthy()
 })
 
+test('test segments', () => {
+  const node = Path.parse('a.0.b')
+  expect(node.match(['a', 0, 'b'])).toEqual(true)
+})
+
 match({
   '*': [[], ['aa'], ['aa', 'bb', 'cc'], ['aa', 'dd', 'gg']],
   '*.a.b': [

--- a/packages/path/src/matcher.ts
+++ b/packages/path/src/matcher.ts
@@ -18,7 +18,7 @@ import {
   RangeExpressionNode,
   DotOperatorNode,
 } from './types'
-import { isEqual, toArr } from './shared'
+import { isEqual, toArr, isSegmentEqual } from './shared'
 
 const isValid = (val) => val !== undefined && val !== null && val !== ''
 
@@ -231,7 +231,7 @@ export class Matcher {
     if (source.length !== target.length) return false
     const match = (pos: number) => {
       const current = () => {
-        const res = isEqual(source[pos], target[pos])
+        const res = isSegmentEqual(source[pos], target[pos])
         if (record && record.score !== undefined) {
           record.score++
         }

--- a/packages/path/src/shared.ts
+++ b/packages/path/src/shared.ts
@@ -74,3 +74,8 @@ export const isEqual = (a: any, b: any) => {
   }
   return a !== a && b !== b
 }
+export const isSegmentEqual = (a: any, b: any) => {
+  a = typeof a === 'symbol' ? a : `${a}`
+  b = typeof b === 'symbol' ? b : `${b}`
+  return a === b
+}


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

I remembered why I used `[...field.path.toArr(), name]` instead of `` `${field.path}.${name}` `` while writing this document, https://github.com/alibaba/formily/pull/1727#issuecomment-875318609

It was because events listening to pattern `${field.path}.${name}` will fail to dispatch if the component is used as an item of an array field, so I usually avoid writing in this "recommended way". Here is a reproduce, https://codesandbox.io/s/objective-wilbur-n2fqe

