### PR TITLE
chore(ts): map @formily/* to src folder during development

### DIFF
--- a/designable/antd/package.json
+++ b/designable/antd/package.json
@@ -23,8 +23,8 @@
   },
   "scripts": {
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd && ts-node copy",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:playground": "webpack-cli --config playground/webpack.prod.ts",
     "start": "webpack-dev-server --config playground/webpack.dev.ts"

--- a/designable/antd/tsconfig.build.json
+++ b/designable/antd/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/designable/antd/tsconfig.build.json
+++ b/designable/antd/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/designable/antd/tsconfig.json
+++ b/designable/antd/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/designable/next/package.json
+++ b/designable/next/package.json
@@ -24,8 +24,8 @@
   "scripts": {
     "start": "dumi dev",
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd && ts-node copy",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:docs": "dumi build"
   },

--- a/designable/next/tsconfig.build.json
+++ b/designable/next/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/designable/next/tsconfig.build.json
+++ b/designable/next/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/designable/next/tsconfig.json
+++ b/designable/next/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/designable/setters/package.json
+++ b/designable/setters/package.json
@@ -23,8 +23,8 @@
   },
   "scripts": {
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd && ts-node copy",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "start": "webpack-dev-server --config playground/webpack.dev.ts"
   },

--- a/designable/setters/tsconfig.build.json
+++ b/designable/setters/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/designable/setters/tsconfig.build.json
+++ b/designable/setters/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/designable/setters/tsconfig.json
+++ b/designable/setters/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/devtools/chrome-extension/tsconfig.build.json
+++ b/devtools/chrome-extension/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/devtools/chrome-extension/tsconfig.build.json
+++ b/devtools/chrome-extension/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/devtools/chrome-extension/tsconfig.json
+++ b/devtools/chrome-extension/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -33,8 +33,8 @@
     "build": "rimraf -rf lib esm dist && npm run create:style && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:style",
     "create:style": "ts-node create-style",
     "build:style": "ts-node build-style",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:docs": "dumi build"
   },

--- a/packages/antd/tsconfig.build.json
+++ b/packages/antd/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/antd/tsconfig.build.json
+++ b/packages/antd/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/antd/tsconfig.json
+++ b/packages/antd/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "start": "dumi dev",
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:global",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:global": "ts-node ../../scripts/build-global",
     "build:docs": "dumi build"

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib"
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/element/tsconfig.build.json
+++ b/packages/element/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/element/tsconfig.build.json
+++ b/packages/element/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/element/tsconfig.json
+++ b/packages/element/tsconfig.json
@@ -4,7 +4,11 @@
     "outDir": "./lib",
     "skipLibCheck": true,
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "plugins": [{ "transform": "./transformer.ts", "after": true }]
   },

--- a/packages/element/tsconfig.json
+++ b/packages/element/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "./lib",
     "skipLibCheck": true,
     "paths": {
-      "@formily/*": ["../*"]
+      "@formily/*": ["../../packages/*", "../../designable/*"]
     },
     "plugins": [{ "transform": "./transformer.ts", "after": true }]
   },

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:global",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:global": "ts-node ../../scripts/build-global"
   },

--- a/packages/json-schema/tsconfig.build.json
+++ b/packages/json-schema/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/json-schema/tsconfig.build.json
+++ b/packages/json-schema/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/json-schema/tsconfig.json
+++ b/packages/json-schema/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -33,8 +33,8 @@
     "build": "rimraf -rf lib esm dist && npm run create:style && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:style",
     "create:style": "ts-node create-style",
     "build:style": "ts-node build-style",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:docs": "dumi build"
   },

--- a/packages/next/tsconfig.build.json
+++ b/packages/next/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/next/tsconfig.build.json
+++ b/packages/next/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.js", "./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*"]
 }

--- a/packages/path/package.json
+++ b/packages/path/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "start": "dumi dev",
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:docs": "dumi build",
     "benchmark": "ts-node ./benchmark"

--- a/packages/path/tsconfig.build.json
+++ b/packages/path/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/path/tsconfig.build.json
+++ b/packages/path/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/path/tsconfig.json
+++ b/packages/path/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "start": "dumi dev",
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:global",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:global": "ts-node ../../scripts/build-global",
     "build:docs": "dumi build"

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/reactive-react/package.json
+++ b/packages/reactive-react/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "start": "dumi dev",
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:docs": "dumi build"
   },

--- a/packages/reactive-react/tsconfig.build.json
+++ b/packages/reactive-react/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/reactive-react/tsconfig.build.json
+++ b/packages/reactive-react/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/reactive-react/tsconfig.json
+++ b/packages/reactive-react/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/reactive-test-cases-for-react18/tsconfig.build.json
+++ b/packages/reactive-test-cases-for-react18/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/reactive-test-cases-for-react18/tsconfig.build.json
+++ b/packages/reactive-test-cases-for-react18/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/reactive-test-cases-for-react18/tsconfig.json
+++ b/packages/reactive-test-cases-for-react18/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib",
-    "allowJs": true,
-    "paths": {
-      "@formily/*": ["../*"]
-    }
+    "allowJs": true
   },
   "include": ["./src/**/*.js"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]

--- a/packages/reactive-vue/package.json
+++ b/packages/reactive-vue/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config"
   },
   "devDependencies": {

--- a/packages/reactive-vue/tsconfig.build.json
+++ b/packages/reactive-vue/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/reactive-vue/tsconfig.build.json
+++ b/packages/reactive-vue/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/reactive-vue/tsconfig.json
+++ b/packages/reactive-vue/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib",
-    "skipLibCheck": true,
-    "paths": {
-      "@formily/*": ["../*"]
-    }
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]

--- a/packages/reactive/package.json
+++ b/packages/reactive/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "start": "dumi dev",
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:global",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:global": "ts-node ../../scripts/build-global",
     "build:docs": "dumi build",

--- a/packages/reactive/tsconfig.build.json
+++ b/packages/reactive/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/reactive/tsconfig.build.json
+++ b/packages/reactive/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/reactive/tsconfig.json
+++ b/packages/reactive/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,8 +26,8 @@
   "gitHead": "ac79c196ae9324889aca5e0501146f9b37b04283",
   "scripts": {
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config"
   },
   "dependencies": {

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "build": "rimraf -rf lib esm dist lib && npm run build:cjs && npm run build:esm && npm run build:umd",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config"
   },
   "dependencies": {

--- a/packages/validator/tsconfig.build.json
+++ b/packages/validator/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/validator/tsconfig.build.json
+++ b/packages/validator/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/validator/tsconfig.json
+++ b/packages/validator/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./lib",
-    "paths": {
-      "@formily/*": ["../*"]
-    }
-  },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -15,8 +15,8 @@
   "scripts": {
     "start": "vuepress dev docs",
     "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:global",
-    "build:cjs": "tsc --declaration",
-    "build:esm": "tsc --declaration --module es2015 --outDir esm",
+    "build:cjs": "tsc --project tsconfig.build.json",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
     "build:global": "ts-node ../../scripts/build-global",
     "build:docs": "vuepress build docs"

--- a/packages/vue/tsconfig.build.json
+++ b/packages/vue/tsconfig.build.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "./lib",
     "paths": {
-      "@formily/*": ["../../packages/*", "../../designable/*"]
+      "@formily/*": [
+        "../../packages/*",
+        "../../designable/*",
+        "../../devtools/*"
+      ]
     },
     "declaration": true
   }

--- a/packages/vue/tsconfig.build.json
+++ b/packages/vue/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "paths": {
+      "@formily/*": ["../../packages/*", "../../designable/*"]
+    },
+    "declaration": true
+  }
+}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib",
-    "skipLibCheck": true,
-    "paths": {
-      "@formily/*": ["../*"]
-    }
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]

--- a/scripts/rollup.base.js
+++ b/scripts/rollup.base.js
@@ -33,7 +33,7 @@ const presets = () => {
   }
   return [
     typescript({
-      tsconfig: './tsconfig.json',
+      tsconfig: './tsconfig.build.json',
       tsconfigOverride: {
         compilerOptions: {
           module: 'ESNext',

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "jsx": "react",
     "paths": {
-      "@formily/*": ["./packages/*/src"]
+      "@formily/*": [
+        "./packages/*/src",
+        "./designable/*/src",
+        "./devtools/*/src"
+      ]
     }
   },
   "exclude": ["./packages/*/esm", "./packages/*/lib"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,11 @@
     "downlevelIteration": true,
     "baseUrl": ".",
     "paths": {
-      "@formily/*": ["./packages/*/src", "./designable/*/src"]
+      "@formily/*": [
+        "./packages/*/src",
+        "./designable/*/src",
+        "./devtools/*/src"
+      ]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "downlevelIteration": true,
     "baseUrl": ".",
     "paths": {
-      "@formily/*": ["./packages/*", "./designable/*"]
+      "@formily/*": ["./packages/*/src", "./designable/*/src"]
     }
   }
 }


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

在开发时让 `@formily/*` 去找对应的 `src` 目录，方便开发，和 https://github.com/alibaba/designable/pull/26 做的事一样。

经测试应用这个修改后 build 的代码除了 `packages/core/esm/shared/internals.d.ts` 其他都没变。具体变化：

```ts
export declare const validateToFeedbacks: (field: Field, triggerType?: ValidatorTriggerType) => Promise<import("../../../validator/esm").IValidateResults>;
```

变为

```ts
export declare const validateToFeedbacks: (field: Field, triggerType?: ValidatorTriggerType) => Promise<import("@formily/validator").IValidateResults>;
```
