### PR TITLE
fix(vue): prop "scope" of SchemaField not work with x-reactions

### DIFF
--- a/packages/vue/src/components/RecursionField.ts
+++ b/packages/vue/src/components/RecursionField.ts
@@ -57,10 +57,7 @@ const RecursionField = observer(
       const createSchema = (schemaProp: IRecursionFieldProps['schema']) =>
         new Schema(schemaProp)
       const createFieldSchema = (schema: Schema) =>
-        schema.compile?.({
-          ...optionsRef.value.scope,
-          ...scopeRef.value,
-        })
+        schema.compile?.(scopeRef.value)
       const schemaRef = shallowRef(createSchema(props.schema))
       const fieldSchemaRef = shallowRef(createFieldSchema(schemaRef.value))
       watch([() => props.schema, scopeRef, optionsRef], () => {
@@ -69,7 +66,7 @@ const RecursionField = observer(
       })
 
       const getPropsFromSchema = (schema: Schema) =>
-        schema?.toFieldProps?.(optionsRef.value)
+        schema?.toFieldProps?.({ ...optionsRef.value, scope: scopeRef.value })
       const fieldPropsRef = shallowRef(getPropsFromSchema(fieldSchemaRef.value))
       watch([fieldSchemaRef, optionsRef], () => {
         fieldPropsRef.value = getPropsFromSchema(fieldSchemaRef.value)


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

fix: prop "scope" of SchemaField not work with reactions