### PR TITLE
fix(reactive-react): fix observer 2nd generic type

### DIFF
--- a/packages/reactive-react/src/observer.ts
+++ b/packages/reactive-react/src/observer.ts
@@ -3,7 +3,10 @@ import hoistNonReactStatics from 'hoist-non-react-statics'
 import { useObserver } from './hooks'
 import { IObserverOptions, IObserverProps } from './types'
 
-export function observer<P, Options extends IObserverOptions>(
+export function observer<
+  P,
+  Options extends IObserverOptions = IObserverOptions
+>(
   component: React.FunctionComponent<P>,
   options?: Options
 ): React.MemoExoticComponent<


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

The 2nd generic param of `observer` should be optional.

```diff
- const Comp = observer<Props, {}>(props => null);
+ const Comp = observer<Props>(props => null);
```