### PR TITLE
feat(vue): support scoped slot (without default)

### DIFF
--- a/packages/vue/docs/demos/questions/scoped-slot.vue
+++ b/packages/vue/docs/demos/questions/scoped-slot.vue
@@ -8,6 +8,7 @@
 import { createForm } from "@formily/core"
 import { FormProvider, createSchemaField } from "@formily/vue"
 import { observer } from "@formily/reactive-vue"
+import { defineComponent } from '@vue/composition-api'
 
 // 普通组件
 const TextPreviewer = {
@@ -18,8 +19,8 @@ const TextPreviewer = {
       context.scopedSlots.default({
         scopedData: "作用域插槽 default 的值",
       }),
-      context.scopedSlots.others({
-        scopedData: "作用域插槽 others 的值（可点击）",
+      context.scopedSlots.other({
+        scopedData: "作用域插槽 other 的值（可通过点击事件传值）",
         onAlert: ($event) => {
           alert($event)
         },
@@ -37,22 +38,22 @@ const ObservedComponent = observer({
   render(h, context) {
     return h(TextPreviewer, {
       scopedSlots: {
-        // 除 default 插槽外，其余可正常使用。
+        // 除 default 插槽需要转换外，其余可正常使用。
         default: (props) => context.scopedSlots.defaultSlot(props),
-        others: (props) => context.scopedSlots.others(props),
+        other: (props) => context.scopedSlots.other(props),
       },
     })
   },
 })
 
-// 作用域插槽组件1
+// 作用域插槽组件 1
 const ScopeSlotComponent1 = {
   functional: true,
   render(h, { props }) {
     return h("span", [props.scopedData])
   },
 }
-// 作用域插槽组件2
+// 作用域插槽组件 2
 const ScopeSlotComponent2 = {
   functional: true,
   render(h, { props }) {
@@ -61,7 +62,7 @@ const ScopeSlotComponent2 = {
       {
         on: {
           click: () => {
-            props.onAlert("通过作用域插槽传递事件进行传值")
+            props.onAlert("作用域插槽传递事件函数，事件发生后进行值的回传")
           },
         },
       },
@@ -84,13 +85,13 @@ const schema = {
       "x-component": "ObservedComponent",
       "x-content": {
         defaultSlot: ScopeSlotComponent1,
-        others: ScopeSlotComponent2,
+        other: ScopeSlotComponent2,
       },
     },
   },
 }
 
-export default {
+export default defineComponent({
   components: { FormProvider, SchemaField },
   data() {
     return {
@@ -98,5 +99,5 @@ export default {
       schema,
     }
   },
-}
+})
 </script>

--- a/packages/vue/docs/demos/questions/scoped-slot.vue
+++ b/packages/vue/docs/demos/questions/scoped-slot.vue
@@ -1,0 +1,102 @@
+<template>
+  <FormProvider :form="form">
+    <SchemaField :schema="schema" />
+  </FormProvider>
+</template>
+
+<script>
+import { createForm } from "@formily/core"
+import { FormProvider, createSchemaField } from "@formily/vue"
+import { observer } from "@formily/reactive-vue"
+
+// 普通组件
+const TextPreviewer = {
+  functional: true,
+  name: "TextPreviewer",
+  render(h, context) {
+    return h("div", null, [
+      context.scopedSlots.default({
+        scopedData: "作用域插槽 default 的值",
+      }),
+      context.scopedSlots.others({
+        scopedData: "作用域插槽 others 的值（可点击）",
+        onAlert: ($event) => {
+          alert($event)
+        },
+      }),
+    ])
+  },
+}
+
+// 响应式组件
+const ObservedComponent = observer({
+  functional: true,
+  components: {
+    TextPreviewer,
+  },
+  render(h, context) {
+    return h(TextPreviewer, {
+      scopedSlots: {
+        // 除 default 插槽外，其余可正常使用。
+        default: (props) => context.scopedSlots.defaultSlot(props),
+        others: (props) => context.scopedSlots.others(props),
+      },
+    })
+  },
+})
+
+// 作用域插槽组件1
+const ScopeSlotComponent1 = {
+  functional: true,
+  render(h, { props }) {
+    return h("span", [props.scopedData])
+  },
+}
+// 作用域插槽组件2
+const ScopeSlotComponent2 = {
+  functional: true,
+  render(h, { props }) {
+    return h(
+      "div",
+      {
+        on: {
+          click: () => {
+            props.onAlert("通过作用域插槽传递事件进行传值")
+          },
+        },
+      },
+      [props.scopedData],
+    )
+  },
+}
+
+const { SchemaField } = createSchemaField({
+  components: {
+    ObservedComponent,
+  },
+})
+
+const schema = {
+  type: "object",
+  properties: {
+    textPreview: {
+      type: "string",
+      "x-component": "ObservedComponent",
+      "x-content": {
+        defaultSlot: ScopeSlotComponent1,
+        others: ScopeSlotComponent2,
+      },
+    },
+  },
+}
+
+export default {
+  components: { FormProvider, SchemaField },
+  data() {
+    return {
+      form: createForm(),
+      schema,
+    }
+  },
+}
+</script>

--- a/packages/vue/docs/questions/README.md
+++ b/packages/vue/docs/questions/README.md
@@ -29,3 +29,13 @@ sidebar: auto
 :::
 
 <dumi-previewer demoPath="questions/named-slot" />
+
+## 如何使用作用域插槽？
+
+插槽中传入函数式组件，并在 `render(h, context)` 通过 `context.props` 访问作用域插槽传入属性。
+
+::: danger
+暂不支持 default 的作用域插槽，可以以 `defaultSlot` 语义上代替，但需在响应式组件中作转换。
+:::
+
+<dumi-previewer demoPath="questions/scoped-slot" />

--- a/packages/vue/docs/questions/README.md
+++ b/packages/vue/docs/questions/README.md
@@ -32,10 +32,10 @@ sidebar: auto
 
 ## 如何使用作用域插槽？
 
-插槽中传入函数式组件，并在 `render(h, context)` 通过 `context.props` 访问作用域插槽传入属性。
+插槽中传入函数式组件，并调用渲染函数时传入 `context` ，可以通过 `context.props` 访问作用域插槽传入的属性。
 
 ::: danger
-暂不支持 default 的作用域插槽，可以以 `defaultSlot` 语义上代替，但需在响应式组件中作转换。
+暂不支持 `default` 作用域插槽，可以以 `defaultSlot` 语义上代替，但需在组件设置响应式时作转换。
 :::
 
 <dumi-previewer demoPath="questions/scoped-slot" />

--- a/packages/vue/src/__tests__/schema.json.spec.ts
+++ b/packages/vue/src/__tests__/schema.json.spec.ts
@@ -76,9 +76,11 @@ const Previewer3: FunctionalComponentOptions = {
           'data-testid': 'previewer3',
         },
       },
-      [context.scopedSlots.defaultSlot({
-        scopedData: '123'
-      })]
+      [
+        context.scopedSlots.defaultSlot({
+          scopedData: '123',
+        }),
+      ]
     )
   },
 }
@@ -366,6 +368,44 @@ describe('x-content', () => {
     })
     expect(queryByTestId('previewer2')).toBeVisible()
     expect(queryByTestId('previewer2').textContent).toEqual('123')
+  })
+
+  test('scoped slot', () => {
+    const form = createForm()
+    const Content = {
+      functional: true,
+      render(h, context) {
+        return h('span', context.props.scopedData)
+      },
+    }
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer3,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'string',
+            'x-component': 'Previewer3',
+            'x-content': {
+              defaultSlot: Content,
+            },
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer3')).toBeVisible()
+    expect(queryByTestId('previewer3').textContent).toEqual('123')
   })
 
   test('scoped slot with scope', () => {

--- a/packages/vue/src/__tests__/schema.json.spec.ts
+++ b/packages/vue/src/__tests__/schema.json.spec.ts
@@ -66,6 +66,23 @@ const Previewer2: FunctionalComponentOptions = {
   },
 }
 
+const Previewer3: FunctionalComponentOptions = {
+  functional: true,
+  render(h, context) {
+    return h(
+      'div',
+      {
+        attrs: {
+          'data-testid': 'previewer3',
+        },
+      },
+      [context.scopedSlots.defaultSlot({
+        scopedData: '123'
+      })]
+    )
+  },
+}
+
 describe('json schema field', () => {
   test('string field', () => {
     const form = createForm()
@@ -349,6 +366,47 @@ describe('x-content', () => {
     })
     expect(queryByTestId('previewer2')).toBeVisible()
     expect(queryByTestId('previewer2').textContent).toEqual('123')
+  })
+
+  test('scoped slot with scope', () => {
+    const form = createForm()
+    const Content = {
+      functional: true,
+      render(h, context) {
+        return h('span', context.props.scopedData)
+      },
+    }
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer3,
+      },
+      scope: {
+        Content,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'string',
+            'x-component': 'Previewer3',
+            'x-content': {
+              defaultSlot: '{{Content}}',
+            },
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer3')).toBeVisible()
+    expect(queryByTestId('previewer3').textContent).toEqual('123')
   })
 })
 

--- a/packages/vue/src/components/RecursionField.ts
+++ b/packages/vue/src/components/RecursionField.ts
@@ -92,7 +92,7 @@ const RecursionField = observer(
           xContentMap['default'] = () => [xContent]
         } else if (isVueOptions(xContent) || typeof xContent === 'function') {
           // is vue component or functional component
-          xContentMap['default'] = props => [h(xContent, { props }, {})]
+          xContentMap['default'] = () => [h(xContent, {}, {})]
         } else if (xContent && typeof xContent === 'object') {
           // for named slots
           Object.keys(xContent).forEach((key) => {

--- a/packages/vue/src/components/RecursionField.ts
+++ b/packages/vue/src/components/RecursionField.ts
@@ -87,6 +87,7 @@ const RecursionField = observer(
         const xContent = fieldSchemaRef.value['x-content']
         const xContentMap: Record<string, (props?: VueComponentProps<any>) => any[]> = {}
 
+        // higher-order function for scoped slot to pass value
         if (typeof xContent === 'string') {
           xContentMap['default'] = () => [xContent]
         } else if (isVueOptions(xContent) || typeof xContent === 'function') {
@@ -105,7 +106,7 @@ const RecursionField = observer(
         }
 
         const getSlots = (children = []) => {
-          const slots: Record<string, (props: VueComponentProps<any>) => any> = {}
+          const slots: Record<string, (props?: VueComponentProps<any>) => any> = {}
 
           if (children.length > 0) {
             slots.default = () => [...children]
@@ -113,9 +114,8 @@ const RecursionField = observer(
 
           Object.keys(xContentMap).forEach((key) => {
             if (key === 'default') {
-              slots[key] = props => [...children, ...xContentMap[key](props)]
+              slots[key] = () => [...children, ...xContentMap[key]()]
             } else {
-              const child = xContent[key]
               slots[key] = props => [...xContentMap[key](props)]
             }
           })

--- a/packages/vue/src/components/RecursionField.ts
+++ b/packages/vue/src/components/RecursionField.ts
@@ -100,7 +100,7 @@ const RecursionField = observer(
             if (typeof child === 'string') {
               xContentMap[key] = () => [child]
             } else if (isVueOptions(child) || typeof child === 'function') {
-              xContentMap[key] = props => [h(child, { props }, {})]
+              xContentMap[key] = (props) => [h(child, { props }, {})]
             }
           })
         }
@@ -116,7 +116,7 @@ const RecursionField = observer(
             if (key === 'default') {
               slots[key] = () => [...children, ...xContentMap[key]()]
             } else {
-              slots[key] = props => [...xContentMap[key](props)]
+              slots[key] = (props) => [...xContentMap[key](props)]
             }
           })
 


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
支持 `x-content: { ...slots }` 中使用作用域插槽，但不支持 `default` 的作用域插槽，可用 `defaultSlot` 替换，在响应式组件中转换对应组件库的 default 插槽。