### PR TITLE
feat(vue): support scoped slot

### DIFF
--- a/packages/vue/docs/demos/questions/scoped-slot.vue
+++ b/packages/vue/docs/demos/questions/scoped-slot.vue
@@ -1,0 +1,88 @@
+<template>
+  <FormProvider :form="form">
+    <SchemaField :schema="schema" />
+  </FormProvider>
+</template>
+
+<script>
+import { createForm } from '@formily/core'
+import { FormProvider, createSchemaField } from '@formily/vue'
+import { observer } from '@formily/reactive-vue'
+
+// 带有作用域插槽的普通组件
+const TextPreviewer = {
+  functional: true,
+  name: 'TextPreviewer',
+  render(h, context) {
+    return h('div', {}, [
+      context.scopedSlots.default({
+        scopedProp: 'default 作用域插槽',
+        onScopedFunc: ($event) => {
+          alert($event)
+        },
+      }),
+    ])
+  },
+}
+
+// 响应式组件
+const ObservedComponent = observer({
+  functional: true,
+  components: {
+    TextPreviewer,
+  },
+  render(h, context) {
+    return h(TextPreviewer, {
+      scopedSlots: {
+        default: (props) => context.scopedSlots.default(props),
+      },
+    })
+  },
+})
+
+// 作用域插槽组件
+const ScopedSlotComponent = {
+  functional: true,
+  render(h, { props }) {
+    return h(
+      'div',
+      {
+        on: {
+          click: () => {
+            props.onScopedFunc('作用域插槽传递事件函数，事件发生后进行值的回传')
+          },
+        },
+      },
+      [props.scopedProp]
+    )
+  },
+}
+
+const { SchemaField } = createSchemaField({
+  components: {
+    ObservedComponent,
+  },
+})
+
+const schema = {
+  type: 'object',
+  properties: {
+    textPreview: {
+      type: 'string',
+      'x-component': 'ObservedComponent',
+      'x-content': {
+        default: ScopedSlotComponent,
+      },
+    },
+  },
+}
+export default {
+  components: { FormProvider, SchemaField },
+  data() {
+    return {
+      form: createForm(),
+      schema,
+    }
+  },
+}
+</script>

--- a/packages/vue/src/__tests__/schema.json.spec.ts
+++ b/packages/vue/src/__tests__/schema.json.spec.ts
@@ -40,7 +40,6 @@ const Input2: FunctionalComponentOptions = {
 const Previewer: FunctionalComponentOptions = {
   functional: true,
   render(h, context) {
-    console.log(context.children)
     return h(
       'div',
       {

--- a/packages/vue/src/__tests__/schema.json.spec.ts
+++ b/packages/vue/src/__tests__/schema.json.spec.ts
@@ -3,6 +3,7 @@ import { Schema } from '@formily/json-schema'
 import { render, waitFor } from '@testing-library/vue'
 import Vue, { FunctionalComponentOptions } from 'vue'
 import { FormProvider, createSchemaField } from '../vue2-components'
+import { h } from 'vue-demi'
 
 Vue.component('FormProvider', FormProvider)
 
@@ -39,6 +40,7 @@ const Input2: FunctionalComponentOptions = {
 const Previewer: FunctionalComponentOptions = {
   functional: true,
   render(h, context) {
+    console.log(context.children)
     return h(
       'div',
       {
@@ -62,6 +64,44 @@ const Previewer2: FunctionalComponentOptions = {
         },
       },
       [context.scopedSlots.content({})]
+    )
+  },
+}
+
+const Previewer3: FunctionalComponentOptions = {
+  functional: true,
+  render(h, context) {
+    return h(
+      'div',
+      {
+        attrs: {
+          'data-testid': 'previewer3',
+        },
+      },
+      [
+        context.scopedSlots.default({
+          scopedProp: '123',
+        }),
+      ]
+    )
+  },
+}
+
+const Previewer4: FunctionalComponentOptions = {
+  functional: true,
+  render(h, context) {
+    return h(
+      'div',
+      {
+        attrs: {
+          'data-testid': 'previewer4',
+        },
+      },
+      [
+        context.scopedSlots.content({
+          scopedProp: '123',
+        }),
+      ]
     )
   },
 }
@@ -198,6 +238,38 @@ describe('x-content', () => {
   })
 
   test('default slot with name default', () => {
+    const form = createForm()
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'string',
+            'x-component': 'Previewer',
+            'x-content': {
+              default: '123',
+            },
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer')).toBeVisible()
+    expect(queryByTestId('previewer').textContent).toEqual('123')
+  })
+
+  test('default slot with name default and component', () => {
     const form = createForm()
     const Content = {
       render(h) {
@@ -349,6 +421,158 @@ describe('x-content', () => {
     })
     expect(queryByTestId('previewer2')).toBeVisible()
     expect(queryByTestId('previewer2').textContent).toEqual('123')
+  })
+
+  test('scoped slot', () => {
+    const form = createForm()
+    const Content = {
+      functional: true,
+      render(h, context) {
+        return h('span', context.props.scopedProp)
+      },
+    }
+
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer3,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'string',
+            'x-component': 'Previewer3',
+            'x-content': Content,
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer3')).toBeVisible()
+    expect(queryByTestId('previewer3').textContent).toEqual('123')
+  })
+
+  test('scoped slot with scope', () => {
+    const form = createForm()
+    const Content = {
+      functional: true,
+      render(h, context) {
+        return h('span', context.props.scopedProp)
+      },
+    }
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer3,
+      },
+      scope: {
+        Content,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'string',
+            'x-component': 'Previewer3',
+            'x-content': '{{Content}}',
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer3')).toBeVisible()
+    expect(queryByTestId('previewer3').textContent).toEqual('123')
+  })
+
+  test('scoped slot with name default', () => {
+    const form = createForm()
+    const Content = {
+      functional: true,
+      render(h, context) {
+        return h('span', context.props.scopedProp)
+      },
+    }
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer3,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'string',
+            'x-component': 'Previewer3',
+            'x-content': {
+              default: Content,
+            },
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer3')).toBeVisible()
+    expect(queryByTestId('previewer3').textContent).toEqual('123')
+  })
+
+  test('scoped slot with name other', () => {
+    const form = createForm()
+    const Content = {
+      functional: true,
+      render(h, context) {
+        return h('span', context.props.scopedProp)
+      },
+    }
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer4,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'string',
+            'x-component': 'Previewer4',
+            'x-content': {
+              content: Content,
+            },
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer4')).toBeVisible()
+    expect(queryByTestId('previewer4').textContent).toEqual('123')
   })
 })
 

--- a/packages/vue/src/__tests__/schema.json.spec.ts
+++ b/packages/vue/src/__tests__/schema.json.spec.ts
@@ -3,7 +3,6 @@ import { Schema } from '@formily/json-schema'
 import { render, waitFor } from '@testing-library/vue'
 import Vue, { FunctionalComponentOptions } from 'vue'
 import { FormProvider, createSchemaField } from '../vue2-components'
-import { h } from 'vue-demi'
 
 Vue.component('FormProvider', FormProvider)
 


### PR DESCRIPTION
using Vue 2 `render(h, {props})` to pass the scoped props.

_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
增加 Vue 版本的作用域插槽（基于 x-content 属性）支持
