### PR TITLE
fix(vue): connect() support scopedSlot content

### DIFF
--- a/packages/vue/docs/demos/questions/scoped-slot.vue
+++ b/packages/vue/docs/demos/questions/scoped-slot.vue
@@ -16,7 +16,7 @@ const TextPreviewer = {
   render(h, context) {
     return h('div', {}, [
       context.scopedSlots.default({
-        scopedProp: 'default 作用域插槽',
+        slotProp: '有 default 作用域插槽组件的插槽属性值',
         onScopedFunc: ($event) => {
           alert($event)
         },
@@ -53,7 +53,7 @@ const ScopedSlotComponent = {
           },
         },
       },
-      [props.scopedProp]
+      [props.slotProp]
     )
   },
 }

--- a/packages/vue/docs/questions/README.md
+++ b/packages/vue/docs/questions/README.md
@@ -32,6 +32,6 @@ sidebar: auto
 
 ## 如何使用作用域插槽？
 
-`x-content` 使用函数式组件时, 渲染函数增加第二个参数，通过其 `props` 成员访问作用域插槽传入属性。
+`x-content` 使用函数式组件时, 渲染函数增加第二个参数，通过其 `props` 成员访问作用域插槽传入属性，支持 observer() 和 connect() 接入组件。
 
 <dumi-previewer demoPath="questions/scoped-slot" />

--- a/packages/vue/src/shared/connect.ts
+++ b/packages/vue/src/shared/connect.ts
@@ -91,28 +91,29 @@ export function mapReadPretty<T extends VueComponent, C extends VueComponent>(
   readPrettyProps?: Record<string, any>
 ) {
   return (target: T) => {
-    const beObserveredComponent = defineComponent({
-      setup(props, { attrs, slots, listeners }: Record<string, any>) {
-        const fieldRef = useField()
-        const field = fieldRef.value
-        return () =>
-          h(
-            field && !isVoidField(field) && field.pattern === 'readPretty'
-              ? component
-              : target,
-            {
-              attrs: {
-                ...readPrettyProps,
-                ...attrs,
+    return observer(
+      defineComponent({
+        setup(props, { attrs, slots, listeners }: Record<string, any>) {
+          const fieldRef = useField()
+          return () => {
+            const field = fieldRef.value
+            return h(
+              field && !isVoidField(field) && field.pattern === 'readPretty'
+                ? component
+                : target,
+              {
+                attrs: {
+                  ...readPrettyProps,
+                  ...attrs,
+                },
+                on: listeners,
               },
-              on: listeners,
-            },
-            slots
-          )
-      },
-    }) as unknown as DefineComponent<VueComponentProps<T>>
-
-    return observer(beObserveredComponent)
+              slots
+            )
+          }
+        },
+      }) as unknown as DefineComponent<VueComponentProps<T>>
+    )
   }
 }
 


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
@vue/composition-api 与 connect() mapProps & mapReadPretty 实现 scopeSlot content 有冲突，故增加 vue 2 组件判断逻辑。