### PR TITLE
build(sourcemap): add "sourcesContent" to the output source map

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "preserveConstEnums": true,
     "skipLibCheck": true,
     "sourceMap": true,
+    "inlineSources": true,
     "declaration": true,
     "experimentalDecorators": true,
     "downlevelIteration": true,


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [ ] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [ ] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [ ] Ensure the test suite passes (`npm test`).
- [ ] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
Set the `inlineSources` option to `true` in `tsconfig.json`.

This is because in the current source map file, I found the sources field that is pointing to the source location (such as `"sources":["../src/index.ts"]` in https://cdn.jsdelivr.net/npm/@formily/react@2.0.0-rc.18/esm/index.js.map). But the `src` folder is not inclued in the published package.
When using some esm bundlers such as `Vite`, the dev server could not find the source file and finally response error with code 404, which means that I can not debug the formily source in browser with source map enabled when using Vite.