### PR TITLE
chore: add ESNext and DOM lib to TS compiler options

### DIFF
--- a/packages/antd/tsconfig.json
+++ b/packages/antd/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
+  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
+  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
+  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }

--- a/packages/element/tsconfig.json
+++ b/packages/element/tsconfig.json
@@ -6,7 +6,8 @@
     "paths": {
       "@formily/*": ["../../packages/*", "../../devtools/*"]
     },
-    "plugins": [{ "transform": "./transformer.ts", "after": true }]
+    "plugins": [{ "transform": "./transformer.ts", "after": true }],
+    "lib": ["ESNext", "DOM"]
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["./esm/*", "./lib/*"]

--- a/packages/grid/tsconfig.json
+++ b/packages/grid/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
+  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*.js", "./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["./src/__tests__/*"]
+  "exclude": ["./src/__tests__/*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
+  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }

--- a/packages/reactive-react/src/shared/gc.ts
+++ b/packages/reactive-react/src/shared/gc.ts
@@ -9,7 +9,7 @@ const registry: FinalizationRegistry<any> =
 type Token = { clean: () => void }
 export class GarbageCollector<T extends object = any> {
   private expireTime: number
-  private request: NodeJS.Timeout
+  private request?: ReturnType<typeof setTimeout>;
   private token: Token
   constructor(clean?: () => void, expireTime = 10_000) {
     this.token = {

--- a/packages/reactive-react/src/shared/global.ts
+++ b/packages/reactive-react/src/shared/global.ts
@@ -19,10 +19,3 @@ function globalSelf() {
 }
 
 export const globalThisPolyfill: Window = globalSelf()
-declare global {
-  export class FinalizationRegistry<T> {
-    constructor(cleanup: (cleanupToken: T) => void)
-    register(object: object, cleanupToken: T, token: T): void
-    unregister(object: object): void
-  }
-}

--- a/packages/reactive-react/tsconfig.json
+++ b/packages/reactive-react/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
+  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*.ts", "./src/**/*.tsx"],
-  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"]
+  "exclude": ["./src/__tests__/*", "./esm/*", "./lib/*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
 }


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
Add `ESNext` and `DOM` lib to TS compiler options to avoid TS compilants about unknown "WeakMap", “symbol”, "window"，etc.

`ESNext` lib is added to all the packages, while the `DOM` lib is added only to the packages using DOM APIs.

So we can remvoe types  patch for `FinalizationRegistry`
