### PR TITLE
refactor(vue): switch type files for vue2/vue3 in postinstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lib/
 esm/
 temp_esm/
 dist/
+type-artefacts/
 build/
 coverage/
 node_modules/

--- a/packages/vue/bin/formily-vue-fix.js
+++ b/packages/vue/bin/formily-vue-fix.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict'
+require('../scripts/postinstall')

--- a/packages/vue/bin/formily-vue-switch.js
+++ b/packages/vue/bin/formily-vue-switch.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict'
+require('../scripts/switch-cli')

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -8,17 +8,25 @@
   "unpkg": "dist/formily.vue.umd.production.js",
   "jsdelivr": "dist/formily.vue.umd.production.js",
   "jsnext:main": "esm",
-  "types": "lib/index.d.ts",
+  "types": "type-artefacts/cur/index.d.ts",
   "engines": {
     "npm": ">=3.0.0"
   },
   "scripts": {
+    "postinstall": "node ./scripts/postinstall.js",
     "start": "vuepress dev docs",
-    "build": "rimraf -rf lib esm dist && npm run build:cjs && npm run build:esm && npm run build:umd",
+    "build": "rimraf -rf lib esm dist type-artefacts && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:types",
     "build:cjs": "tsc --project tsconfig.build.json",
     "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir esm",
     "build:umd": "rollup --config",
+    "build:types": "npm run build:types-vue2 && npm run build:types-vue3 && rimraf type-artefacts/**/*.js type-artefacts/**/**/*.js",
+    "build:types-vue2": "tsc --project tsconfig.types.json --outDir type-artefacts/v2",
+    "build:types-vue3": "npx vue-demi-switch 3 vue3 && tsc --project tsconfig.types.json --outDir type-artefacts/v3 && tsc --project tsconfig.types.json --outDir type-artefacts/cur && npx vue-demi-switch 2",
     "build:docs": "vuepress build docs"
+  },
+  "bin": {
+    "formily-vue-fix": "bin/formily-vue-fix.js",
+    "formily-vue-switch": "bin/formily-vue-switch.js"
   },
   "devDependencies": {
     "@ant-design/icons": "^2.1.1",
@@ -32,6 +40,7 @@
     "codesandbox": "^2.2.3",
     "core-js": "^2.4.0",
     "vue": "^2.6.12",
+    "vue3": "npm:vue@3",
     "vuepress": "^1.8.2",
     "vuepress-plugin-typescript": "^0.3.1"
   },
@@ -42,8 +51,7 @@
     "@formily/reactive-vue": "2.0.6",
     "@formily/shared": "2.0.6",
     "@formily/validator": "2.0.6",
-    "@type-helper/vue2": "npm:vue@2",
-    "@type-helper/vue3": "npm:vue@3",
+    "fs-extra": "^10.0.0",
     "vue-demi": "^0.9.0",
     "vue-frag": "^1.1.4"
   },

--- a/packages/vue/scripts/postinstall.js
+++ b/packages/vue/scripts/postinstall.js
@@ -2,8 +2,12 @@ const { switchVersion, loadModule } = require('./utils.js')
 
 const Vue = loadModule('vue')
 
-if (Vue.version.startsWith('2.')) {
-  switchVersion(2)
-} else if (Vue.version.startsWith('3.')) {
-  switchVersion(3)
+try {
+  if (Vue.version.startsWith('2.')) {
+    switchVersion(2)
+  } else if (Vue.version.startsWith('3.')) {
+    switchVersion(3)
+  }
+} catch (err) {
+  // nothing to do
 }

--- a/packages/vue/scripts/postinstall.js
+++ b/packages/vue/scripts/postinstall.js
@@ -1,0 +1,9 @@
+const { switchVersion, loadModule } = require('./utils.js')
+
+const Vue = loadModule('vue')
+
+if (Vue.version.startsWith('2.')) {
+  switchVersion(2)
+} else if (Vue.version.startsWith('3.')) {
+  switchVersion(3)
+}

--- a/packages/vue/scripts/switch-cli.js
+++ b/packages/vue/scripts/switch-cli.js
@@ -1,0 +1,24 @@
+const { switchVersion } = require('./utils.js')
+const {
+  switchVersion: switchVueDemiVersion,
+} = require('vue-demi/scripts/utils.js')
+
+const version = process.argv[2]
+const vueEntry = process.argv[3] || 'vue'
+
+if (version == '2') {
+  switchVersion(2)
+  console.log(`[formily-vue] Switched types for Vue 2`)
+  switchVueDemiVersion(2, vueEntry)
+  console.log(`[vue-demi] Switched for Vue 2 (entry: "${vueEntry}")`)
+} else if (version == '3') {
+  switchVersion(3)
+  console.log(`[formily-vue] Switched types for Vue 3`)
+  switchVueDemiVersion(3, vueEntry)
+  console.log(`[vue-demi] Switched for Vue 3 (entry: "${vueEntry}")`)
+} else {
+  console.warn(
+    `[formily-vue] expecting version "2" or "3" but got "${version}"`
+  )
+  process.exit(1)
+}

--- a/packages/vue/scripts/utils.js
+++ b/packages/vue/scripts/utils.js
@@ -1,0 +1,13 @@
+const { loadModule } = require('vue-demi/scripts/utils.js')
+const fs = require('fs-extra')
+const path = require('path')
+
+const dir = path.resolve(__dirname, '..', 'type-artefacts')
+
+function switchVersion(version) {
+  fs.emptyDirSync(`${dir}/cur`)
+  fs.copySync(`${dir}/v${version}`, `${dir}/cur`)
+}
+
+module.exports.loadModule = loadModule
+module.exports.switchVersion = switchVersion

--- a/packages/vue/src/components/ArrayField.ts
+++ b/packages/vue/src/components/ArrayField.ts
@@ -5,107 +5,77 @@ import ReactiveField from './ReactiveField'
 import { FieldSymbol } from '../shared/context'
 import h from '../shared/h'
 import { getRawComponent } from '../utils/getRawComponent'
-import { observer } from '@formily/reactive-vue'
 
 import type { IArrayFieldProps, DefineComponent } from '../types'
 
-export default observer(
-  defineComponent<IArrayFieldProps>({
-    name: 'ArrayField',
-    props: {
-      name: {},
-      title: {},
-      description: {},
-      value: {},
-      initialValue: {},
-      basePath: {},
-      decorator: Array,
-      component: Array,
-      display: String,
-      pattern: String,
-      required: {
-        type: Boolean,
-        default: undefined,
-      },
-      validateFirst: {
-        type: Boolean,
-        default: undefined,
-      },
-      hidden: {
-        type: Boolean,
-        default: undefined,
-      },
-      visible: {
-        type: Boolean,
-        default: undefined,
-      },
-      editable: {
-        type: Boolean,
-        default: undefined,
-      },
-      disabled: {
-        type: Boolean,
-        default: undefined,
-      },
-      readOnly: {
-        type: Boolean,
-        default: undefined,
-      },
-      readPretty: {
-        type: Boolean,
-        default: undefined,
-      },
-      dataSource: {},
-      validator: {},
-      reactions: [Array, Function],
-    },
-    setup(props: IArrayFieldProps, { slots }) {
-      const formRef = useForm()
-      const parentRef = useField()
+export default defineComponent({
+  name: 'ArrayField',
+  props: [
+    'name',
+    'basePath',
+    'title',
+    'description',
+    'value',
+    'initialValue',
+    'required',
+    'display',
+    'pattern',
+    'hidden',
+    'visible',
+    'editable',
+    'disabled',
+    'readOnly',
+    'readPretty',
+    'dataSource',
+    'validateFirst',
+    'validator',
+    'decorator',
+    'component',
+    'reactions',
+    'content',
+    'data',
+  ],
+  setup(props: IArrayFieldProps, { slots }) {
+    const formRef = useForm()
+    const parentRef = useField()
 
-      const basePath = computed(() =>
-        props.basePath !== undefined
-          ? props.basePath
-          : parentRef?.value?.address
-      )
-      const createField = () =>
-        formRef.value.createArrayField({
-          ...props,
-          basePath: basePath.value,
-          ...getRawComponent(props),
-        })
-      const [fieldRef, checker] = useAttach(createField())
-      watch(
-        () => props,
-        () => (fieldRef.value = checker(createField())),
-        { deep: true }
-      )
-      watch(
-        [formRef, parentRef],
-        () => (fieldRef.value = checker(createField()))
-      )
+    const basePath = computed(() =>
+      props.basePath !== undefined ? props.basePath : parentRef?.value?.address
+    )
+    const createField = () =>
+      formRef.value.createArrayField({
+        ...props,
+        basePath: basePath.value,
+        ...getRawComponent(props),
+      })
+    const [fieldRef, checker] = useAttach(createField())
+    watch(
+      () => props,
+      () => (fieldRef.value = checker(createField())),
+      { deep: true }
+    )
+    watch([formRef, parentRef], () => (fieldRef.value = checker(createField())))
 
-      provide(FieldSymbol, fieldRef)
+    provide(FieldSymbol, fieldRef)
 
-      return () => {
-        const field = fieldRef.value
-        const componentData = {
-          props: {
-            field,
-          },
-        }
-        const children = {
-          ...slots,
-        }
-        if (slots.default) {
-          children.default = () =>
-            slots.default({
-              field: field,
-              form: field.form,
-            })
-        }
-        return h(ReactiveField, componentData, children)
+    return () => {
+      const field = fieldRef.value
+      const componentData = {
+        props: {
+          field,
+        },
       }
-    },
-  }) as unknown as DefineComponent<IArrayFieldProps>
-)
+      const children = {
+        ...slots,
+      }
+      if (slots.default) {
+        children.default = () =>
+          slots.default({
+            field: field,
+            form: field.form,
+          })
+      }
+      return h(ReactiveField, componentData, children)
+    }
+  },
+}) as DefineComponent<IArrayFieldProps>

--- a/packages/vue/src/components/Field.ts
+++ b/packages/vue/src/components/Field.ts
@@ -8,55 +8,33 @@ import { getRawComponent } from '../utils/getRawComponent'
 
 import type { IFieldProps, DefineComponent } from '../types'
 
-export default defineComponent<IFieldProps>({
+export default defineComponent({
   name: 'Field',
-  props: {
-    name: {},
-    title: {},
-    description: {},
-    value: {},
-    initialValue: {},
-    basePath: {},
-    decorator: Array,
-    component: Array,
-    display: String,
-    pattern: String,
-    required: {
-      type: Boolean,
-      default: undefined,
-    },
-    validateFirst: {
-      type: Boolean,
-      default: undefined,
-    },
-    hidden: {
-      type: Boolean,
-      default: undefined,
-    },
-    visible: {
-      type: Boolean,
-      default: undefined,
-    },
-    editable: {
-      type: Boolean,
-      default: undefined,
-    },
-    disabled: {
-      type: Boolean,
-      default: undefined,
-    },
-    readOnly: {
-      type: Boolean,
-      default: undefined,
-    },
-    readPretty: {
-      type: Boolean,
-      default: undefined,
-    },
-    dataSource: {},
-    validator: {},
-    reactions: [Array, Function],
-  },
+  props: [
+    'name',
+    'basePath',
+    'title',
+    'description',
+    'value',
+    'initialValue',
+    'required',
+    'display',
+    'pattern',
+    'hidden',
+    'visible',
+    'editable',
+    'disabled',
+    'readOnly',
+    'readPretty',
+    'dataSource',
+    'validateFirst',
+    'validator',
+    'decorator',
+    'component',
+    'reactions',
+    'content',
+    'data',
+  ],
   setup(props: IFieldProps, { slots }) {
     const formRef = useForm()
     const parentRef = useField()
@@ -100,4 +78,4 @@ export default defineComponent<IFieldProps>({
       return h(ReactiveField, componentData, children)
     }
   },
-}) as unknown as DefineComponent<IFieldProps>
+}) as DefineComponent<IFieldProps>

--- a/packages/vue/src/components/FormConsumer.ts
+++ b/packages/vue/src/components/FormConsumer.ts
@@ -4,8 +4,6 @@ import { useForm } from '../hooks'
 import h from '../shared/h'
 import { Fragment } from '../shared/fragment'
 
-import type { DefineComponent } from '../types'
-
 export default observer(
   defineComponent({
     name: 'FormConsumer',
@@ -25,5 +23,5 @@ export default observer(
         return h(Fragment, {}, children)
       }
     },
-  }) as unknown as DefineComponent
+  })
 )

--- a/packages/vue/src/components/FormProvider.ts
+++ b/packages/vue/src/components/FormProvider.ts
@@ -7,23 +7,16 @@ import {
   SchemaExpressionScopeSymbol,
   SchemaOptionsSymbol,
 } from '../shared/context'
-import { IProviderProps } from '../types'
+import { IProviderProps, DefineComponent } from '../types'
 import { useAttach } from '../hooks/useAttach'
 import { useInjectionCleaner } from '../hooks/useInjectionCleaner'
 import h from '../shared/h'
 import { Fragment } from '../shared/fragment'
 
-import type { DefineComponent } from '../types'
-
-export default defineComponent<IProviderProps>({
+export default defineComponent({
   name: 'FormProvider',
   inheritAttrs: false,
-  props: {
-    form: {
-      type: Object,
-      required: true,
-    },
-  },
+  props: ['form'],
   setup(props: IProviderProps, { attrs, slots }) {
     const getForm = () => props.form
     const [formRef, checker] = useAttach(getForm())
@@ -43,4 +36,4 @@ export default defineComponent<IProviderProps>({
 
     return () => h(Fragment, { attrs }, slots)
   },
-}) as unknown as DefineComponent<IProviderProps>
+}) as DefineComponent<IProviderProps>

--- a/packages/vue/src/components/ObjectField.ts
+++ b/packages/vue/src/components/ObjectField.ts
@@ -2,110 +2,80 @@ import { provide, defineComponent, computed, watch } from 'vue-demi'
 import { useField, useForm } from '../hooks'
 import { useAttach } from '../hooks/useAttach'
 import ReactiveField from './ReactiveField'
-import { observer } from '@formily/reactive-vue'
 import { FieldSymbol } from '../shared/context'
 import h from '../shared/h'
 import { getRawComponent } from '../utils/getRawComponent'
 
 import type { IObjectFieldProps, DefineComponent } from '../types'
 
-export default observer(
-  defineComponent<IObjectFieldProps>({
-    name: 'ObjectField',
-    props: {
-      name: {},
-      title: {},
-      description: {},
-      value: {},
-      initialValue: {},
-      basePath: {},
-      decorator: Array,
-      component: Array,
-      display: String,
-      pattern: String,
-      required: {
-        type: Boolean,
-        default: undefined,
-      },
-      validateFirst: {
-        type: Boolean,
-        default: undefined,
-      },
-      hidden: {
-        type: Boolean,
-        default: undefined,
-      },
-      visible: {
-        type: Boolean,
-        default: undefined,
-      },
-      editable: {
-        type: Boolean,
-        default: undefined,
-      },
-      disabled: {
-        type: Boolean,
-        default: undefined,
-      },
-      readOnly: {
-        type: Boolean,
-        default: undefined,
-      },
-      readPretty: {
-        type: Boolean,
-        default: undefined,
-      },
-      dataSource: {},
-      validator: {},
-      reactions: [Array, Function],
-    },
-    setup(props: IObjectFieldProps, { slots }) {
-      const formRef = useForm()
-      const parentRef = useField()
+export default defineComponent({
+  name: 'ObjectField',
+  props: [
+    'name',
+    'basePath',
+    'title',
+    'description',
+    'value',
+    'initialValue',
+    'required',
+    'display',
+    'pattern',
+    'hidden',
+    'visible',
+    'editable',
+    'disabled',
+    'readOnly',
+    'readPretty',
+    'dataSource',
+    'validateFirst',
+    'validator',
+    'decorator',
+    'component',
+    'reactions',
+    'content',
+    'data',
+  ],
+  setup(props: IObjectFieldProps, { slots }) {
+    const formRef = useForm()
+    const parentRef = useField()
 
-      const basePath = computed(() =>
-        props.basePath !== undefined
-          ? props.basePath
-          : parentRef?.value?.address
-      )
-      const createField = () =>
-        formRef.value.createObjectField({
-          ...props,
-          basePath: basePath.value,
-          ...getRawComponent(props),
-        })
-      const [fieldRef, checker] = useAttach(createField())
-      watch(
-        () => props,
-        () => (fieldRef.value = checker(createField())),
-        { deep: true }
-      )
-      watch(
-        [formRef, parentRef],
-        () => (fieldRef.value = checker(createField()))
-      )
+    const basePath = computed(() =>
+      props.basePath !== undefined ? props.basePath : parentRef?.value?.address
+    )
+    const createField = () =>
+      formRef.value.createObjectField({
+        ...props,
+        basePath: basePath.value,
+        ...getRawComponent(props),
+      })
+    const [fieldRef, checker] = useAttach(createField())
+    watch(
+      () => props,
+      () => (fieldRef.value = checker(createField())),
+      { deep: true }
+    )
+    watch([formRef, parentRef], () => (fieldRef.value = checker(createField())))
 
-      provide(FieldSymbol, fieldRef)
+    provide(FieldSymbol, fieldRef)
 
-      return () => {
-        const field = fieldRef.value
-        const componentData = {
-          props: {
-            field,
-          },
-        }
-        const children = {
-          ...slots,
-        }
-        if (slots.default) {
-          children.default = () =>
-            slots.default({
-              field: field,
-              form: field.form,
-            })
-        }
-        return h(ReactiveField, componentData, children)
+    return () => {
+      const field = fieldRef.value
+      const componentData = {
+        props: {
+          field,
+        },
       }
-    },
-  }) as unknown as DefineComponent<IObjectFieldProps>
-)
+      const children = {
+        ...slots,
+      }
+      if (slots.default) {
+        children.default = () =>
+          slots.default({
+            field: field,
+            form: field.form,
+          })
+      }
+      return h(ReactiveField, componentData, children)
+    }
+  },
+}) as DefineComponent<IObjectFieldProps>

--- a/packages/vue/src/components/ReactiveField.ts
+++ b/packages/vue/src/components/ReactiveField.ts
@@ -10,8 +10,8 @@ import { Fragment } from '../shared/fragment'
 import type {
   IReactiveFieldProps,
   VueComponent,
-  DefineComponent,
   VueComponentProps,
+  DefineComponent,
 } from '../types'
 
 function isVueOptions(options: any) {
@@ -26,7 +26,7 @@ function isVueOptions(options: any) {
 }
 
 export default observer(
-  defineComponent<IReactiveFieldProps>({
+  defineComponent({
     name: 'ReactiveField',
     props: ['field'],
     setup(props: IReactiveFieldProps, { slots }) {
@@ -212,5 +212,5 @@ export default observer(
         return h(Fragment, { key }, children)
       }
     },
-  }) as unknown as DefineComponent<IReactiveFieldProps>
+  }) as DefineComponent<IReactiveFieldProps>
 )

--- a/packages/vue/src/components/RecursionField.ts
+++ b/packages/vue/src/components/RecursionField.ts
@@ -2,7 +2,6 @@ import { inject, provide, watch, defineComponent, shallowRef } from 'vue-demi'
 import { GeneralField } from '@formily/core'
 import { isFn, isValid } from '@formily/shared'
 import { Schema } from '@formily/json-schema'
-import { observer } from '@formily/reactive-vue'
 import {
   SchemaSymbol,
   SchemaOptionsSymbol,
@@ -18,156 +17,119 @@ import { Fragment } from '../shared/fragment'
 
 import type { IRecursionFieldProps, DefineComponent } from '../types'
 
-const RecursionField = observer(
-  defineComponent<IRecursionFieldProps>({
-    name: 'RecursionField',
-    inheritAttrs: false,
-    props: {
-      schema: {
-        required: true,
-      },
-      name: [String, Number],
-      basePath: {},
-      onlyRenderProperties: {
-        type: Boolean,
-        default: undefined,
-      },
-      onlyRenderSelf: {
-        type: Boolean,
-        default: undefined,
-      },
-      mapProperties: {},
-      filterProperties: {},
-    },
-    setup(props: IRecursionFieldProps) {
-      const parentRef = useField()
-      const optionsRef = inject(SchemaOptionsSymbol)
-      const scopeRef = inject(SchemaExpressionScopeSymbol)
-      const createSchema = (schemaProp: IRecursionFieldProps['schema']) =>
-        new Schema(schemaProp)
-      const fieldSchemaRef = shallowRef(createSchema(props.schema))
+const RecursionField = defineComponent({
+  name: 'RecursionField',
+  inheritAttrs: false,
+  props: [
+    'schema',
+    'name',
+    'basePath',
+    'onlyRenderProperties',
+    'onlyRenderSelf',
+    'mapProperties',
+    'filterProperties',
+  ],
+  setup(props: IRecursionFieldProps) {
+    const parentRef = useField()
+    const optionsRef = inject(SchemaOptionsSymbol)
+    const scopeRef = inject(SchemaExpressionScopeSymbol)
+    const createSchema = (schemaProp: IRecursionFieldProps['schema']) =>
+      new Schema(schemaProp)
+    const fieldSchemaRef = shallowRef(createSchema(props.schema))
 
-      watch([() => props.schema], () => {
-        fieldSchemaRef.value = createSchema(props.schema)
+    watch([() => props.schema], () => {
+      fieldSchemaRef.value = createSchema(props.schema)
+    })
+
+    const getPropsFromSchema = (schema: Schema) =>
+      schema?.toFieldProps?.({
+        ...optionsRef.value,
+        get scope() {
+          return {
+            ...optionsRef.value.scope,
+            ...scopeRef.value,
+          }
+        },
       })
+    const fieldPropsRef = shallowRef(getPropsFromSchema(fieldSchemaRef.value))
 
-      const getPropsFromSchema = (schema: Schema) =>
-        schema?.toFieldProps?.({
-          ...optionsRef.value,
-          get scope() {
-            return {
-              ...optionsRef.value.scope,
-              ...scopeRef.value,
+    watch([fieldSchemaRef, optionsRef], () => {
+      fieldPropsRef.value = getPropsFromSchema(fieldSchemaRef.value)
+    })
+
+    const getBasePath = () => {
+      if (props.onlyRenderProperties) {
+        return props.basePath || parentRef?.value?.address.concat(props.name)
+      }
+      return props.basePath || parentRef?.value?.address
+    }
+
+    provide(SchemaSymbol, fieldSchemaRef)
+
+    return () => {
+      const basePath = getBasePath()
+      const fieldProps = fieldPropsRef.value
+
+      const renderProperties = (field?: GeneralField) => {
+        if (props.onlyRenderSelf) return
+        const properties = Schema.getOrderProperties(fieldSchemaRef.value)
+        if (!properties.length) return
+        const children = properties.map(({ schema: item, key: name }) => {
+          const base = field?.address || basePath
+          let schema: Schema = item
+          if (isFn(props.mapProperties)) {
+            const mapped = props.mapProperties(item, name)
+            if (mapped) {
+              schema = mapped
             }
-          },
+          }
+          if (isFn(props.filterProperties)) {
+            if (props.filterProperties(schema, name) === false) {
+              return null
+            }
+          }
+          return h(
+            RecursionField,
+            {
+              key: name,
+              attrs: {
+                schema,
+                name,
+                basePath: base,
+              },
+            },
+            {}
+          )
         })
-      const fieldPropsRef = shallowRef(getPropsFromSchema(fieldSchemaRef.value))
 
-      watch([fieldSchemaRef, optionsRef], () => {
-        fieldPropsRef.value = getPropsFromSchema(fieldSchemaRef.value)
-      })
-
-      const getBasePath = () => {
-        if (props.onlyRenderProperties) {
-          return props.basePath || parentRef?.value?.address.concat(props.name)
+        const slots: Record<string, () => any> = {}
+        if (children.length > 0) {
+          slots.default = () => [...children]
         }
-        return props.basePath || parentRef?.value?.address
+
+        return h(Fragment, {}, slots)
       }
 
-      provide(SchemaSymbol, fieldSchemaRef)
-
-      return () => {
-        const basePath = getBasePath()
-        const fieldProps = fieldPropsRef.value
-
-        const renderProperties = (field?: GeneralField) => {
-          if (props.onlyRenderSelf) return
-          const properties = Schema.getOrderProperties(fieldSchemaRef.value)
-          if (!properties.length) return
-          const children = properties.map(({ schema: item, key: name }) => {
-            const base = field?.address || basePath
-            let schema: Schema = item
-            if (isFn(props.mapProperties)) {
-              const mapped = props.mapProperties(item, name)
-              if (mapped) {
-                schema = mapped
-              }
-            }
-            if (isFn(props.filterProperties)) {
-              if (props.filterProperties(schema, name) === false) {
-                return null
-              }
-            }
-            return h(
-              RecursionField,
-              {
-                key: name,
-                attrs: {
-                  schema,
-                  name,
-                  basePath: base,
-                },
-              },
-              {}
-            )
-          })
-
-          const slots: Record<string, () => any> = {}
-          if (children.length > 0) {
-            slots.default = () => [...children]
-          }
-
-          return h(Fragment, {}, slots)
-        }
-
-        const render = () => {
-          if (!isValid(props.name)) return renderProperties()
-          if (fieldSchemaRef.value.type === 'object') {
-            if (props.onlyRenderProperties) return renderProperties()
-            return h(
-              ObjectField,
-              {
-                attrs: {
-                  ...fieldProps,
-                  name: props.name,
-                  basePath: basePath,
-                },
-              },
-              {
-                default: ({ field }) => [renderProperties(field)],
-              }
-            )
-          } else if (fieldSchemaRef.value.type === 'array') {
-            return h(
-              ArrayField,
-              {
-                attrs: {
-                  ...fieldProps,
-                  name: props.name,
-                  basePath: basePath,
-                },
-              },
-              {}
-            )
-          } else if (fieldSchemaRef.value.type === 'void') {
-            if (props.onlyRenderProperties) return renderProperties()
-            return h(
-              VoidField,
-              {
-                attrs: {
-                  ...fieldProps,
-                  name: props.name,
-                  basePath: basePath,
-                },
-              },
-              {
-                default: ({ field }) => [renderProperties(field)],
-              }
-            )
-          }
-
+      const render = () => {
+        if (!isValid(props.name)) return renderProperties()
+        if (fieldSchemaRef.value.type === 'object') {
+          if (props.onlyRenderProperties) return renderProperties()
           return h(
-            Field,
+            ObjectField,
+            {
+              attrs: {
+                ...fieldProps,
+                name: props.name,
+                basePath: basePath,
+              },
+            },
+            {
+              default: ({ field }) => [renderProperties(field)],
+            }
+          )
+        } else if (fieldSchemaRef.value.type === 'array') {
+          return h(
+            ArrayField,
             {
               attrs: {
                 ...fieldProps,
@@ -177,14 +139,41 @@ const RecursionField = observer(
             },
             {}
           )
+        } else if (fieldSchemaRef.value.type === 'void') {
+          if (props.onlyRenderProperties) return renderProperties()
+          return h(
+            VoidField,
+            {
+              attrs: {
+                ...fieldProps,
+                name: props.name,
+                basePath: basePath,
+              },
+            },
+            {
+              default: ({ field }) => [renderProperties(field)],
+            }
+          )
         }
 
-        if (!fieldSchemaRef.value) return
-
-        return render()
+        return h(
+          Field,
+          {
+            attrs: {
+              ...fieldProps,
+              name: props.name,
+              basePath: basePath,
+            },
+          },
+          {}
+        )
       }
-    },
-  }) as unknown as DefineComponent<IRecursionFieldProps>
-)
+
+      if (!fieldSchemaRef.value) return
+
+      return render()
+    }
+  },
+}) as DefineComponent<IRecursionFieldProps>
 
 export default RecursionField

--- a/packages/vue/src/components/SchemaField.ts
+++ b/packages/vue/src/components/SchemaField.ts
@@ -15,7 +15,6 @@ import {
 } from '../shared'
 import {
   ComponentPath,
-  VueComponent,
   ISchemaFieldVueFactoryOptions,
   SchemaVueComponents,
   ISchemaFieldProps,
@@ -25,94 +24,7 @@ import {
 import { resolveSchemaProps } from '../utils/resolveSchemaProps'
 import { h } from '../shared/h'
 import { Fragment } from '../shared/fragment'
-
 import type { DefineComponent } from '../types'
-
-const env = {
-  nonameId: 0,
-}
-
-const getRandomName = () => {
-  return `NO_NAME_FIELD_$${env.nonameId++}`
-}
-
-const markupProps = {
-  version: String,
-  name: [String, Number],
-  title: {},
-  description: {},
-  default: {},
-  readOnly: {
-    type: Boolean,
-    default: undefined,
-  },
-  writeOnly: {
-    type: Boolean,
-    default: undefined,
-  },
-  enum: {},
-  const: {},
-  multipleOf: Number,
-  maximum: Number,
-  exclusiveMaximum: Number,
-  minimum: Number,
-  exclusiveMinimum: Number,
-  maxLength: Number,
-  minLength: Number,
-  pattern: {},
-  maxItems: Number,
-  minItems: Number,
-  uniqueItems: {
-    type: Boolean,
-    default: undefined,
-  },
-  maxProperties: Number,
-  minProperties: Number,
-  required: {
-    type: [Boolean, Array, String],
-    default: undefined,
-  },
-  format: String,
-  properties: {},
-  items: {},
-  additionalItems: {},
-  patternProperties: {},
-  additionalProperties: {},
-  xIndex: Number,
-  xPattern: {},
-  xDisplay: {},
-  xValidator: {},
-  xDecorator: {},
-  xDecoratorProps: {},
-  xComponent: {},
-  xComponentProps: {},
-  xReactions: {},
-  xContent: {},
-  xVisible: {
-    type: Boolean,
-    default: undefined,
-  },
-  xHidden: {
-    type: Boolean,
-    default: undefined,
-  },
-  xDisabled: {
-    type: Boolean,
-    default: undefined,
-  },
-  xEditable: {
-    type: Boolean,
-    default: undefined,
-  },
-  xReadOnly: {
-    type: Boolean,
-    default: undefined,
-  },
-  xReadPretty: {
-    type: Boolean,
-    default: undefined,
-  },
-}
 
 type SchemaFieldComponents = {
   SchemaField: DefineComponent<ISchemaFieldProps>
@@ -127,65 +39,97 @@ type SchemaFieldComponents = {
   SchemaNumberField: DefineComponent<ISchemaTypeFieldProps>
 }
 
+const env = {
+  nonameId: 0,
+}
+
+const getRandomName = () => {
+  return `NO_NAME_FIELD_$${env.nonameId++}`
+}
+
+const markupProps = [
+  'version',
+  'name',
+  'title',
+  'description',
+  'default',
+  'readOnly',
+  'writeOnly',
+  'enum',
+  'const',
+  'multipleOf',
+  'maximum',
+  'exclusiveMaximum',
+  'minimum',
+  'exclusiveMinimum',
+  'maxLength',
+  'minLength',
+  'pattern',
+  'maxItems',
+  'minItems',
+  'uniqueItems',
+  'maxProperties',
+  'minProperties',
+  'required',
+  'format',
+  'properties',
+  'items',
+  'additionalItems',
+  'patternProperties',
+  'additionalProperties',
+  'xIndex',
+  'xPattern',
+  'xDisplay',
+  'xValidator',
+  'xDecorator',
+  'xDecoratorProps',
+  'xComponent',
+  'xComponentProps',
+  'xReactions',
+  'xContent',
+  'xVisible',
+  'xHidden',
+  'xDisabled',
+  'xEditable',
+  'xReadOnly',
+  'xReadPretty',
+]
+
 export function createSchemaField<
   Components extends SchemaVueComponents = SchemaVueComponents
 >(options: ISchemaFieldVueFactoryOptions<Components>): SchemaFieldComponents {
-  const SchemaField = defineComponent<
-    ISchemaFieldProps<VueComponent, VueComponent>
-  >({
+  const SchemaField = defineComponent({
     name: 'SchemaField',
     inheritAttrs: false,
-    props: {
-      schema: {},
-      scope: {},
-      components: {},
-      basePath: {},
-      title: {},
-      description: {},
-      value: {},
-      initialValue: {},
-      validator: {},
-      dataSource: {},
-      name: [String, Number],
-      decorator: Array,
-      component: Array,
-      reactions: Array,
-      display: String,
-      pattern: String,
-      required: {
-        type: Boolean,
-        default: undefined,
-      },
-      validateFirst: {
-        type: Boolean,
-        default: undefined,
-      },
-      hidden: {
-        type: Boolean,
-        default: undefined,
-      },
-      visible: {
-        type: Boolean,
-        default: undefined,
-      },
-      editable: {
-        type: Boolean,
-        default: undefined,
-      },
-      disabled: {
-        type: Boolean,
-        default: undefined,
-      },
-      readOnly: {
-        type: Boolean,
-        default: undefined,
-      },
-      readPretty: {
-        type: Boolean,
-        default: undefined,
-      },
-    },
-    setup(props: ISchemaFieldProps<VueComponent, VueComponent>, { slots }) {
+    props: [
+      'schema',
+      'components',
+      'scope',
+      'name',
+      'basePath',
+      'title',
+      'description',
+      'value',
+      'initialValue',
+      'required',
+      'display',
+      'pattern',
+      'hidden',
+      'visible',
+      'editable',
+      'disabled',
+      'readOnly',
+      'readPretty',
+      'dataSource',
+      'validateFirst',
+      'validator',
+      'decorator',
+      'component',
+      'reactions',
+      'content',
+      'data',
+    ],
+    setup(props: ISchemaFieldProps, { slots }) {
       const schemaRef = computed(() =>
         Schema.isSchemaInstance(props.schema)
           ? props.schema
@@ -252,16 +196,10 @@ export function createSchemaField<
     },
   })
 
-  const MarkupField = defineComponent<
-    ISchemaMarkupFieldProps<
-      Components,
-      ComponentPath<Components>,
-      ComponentPath<Components>
-    >
-  >({
+  const MarkupField = defineComponent({
     name: 'MarkupField',
-    props: Object.assign({}, markupProps, { type: String }),
-    setup(props, { slots }) {
+    props: [...markupProps, 'type'],
+    setup(props: ISchemaMarkupFieldProps, { slots }) {
       const parentRef = inject(SchemaMarkupSymbol, null)
       if (!parentRef || !parentRef.value) return () => h(Fragment, {}, {})
       const resolvedProps = resolveSchemaProps(props)
@@ -305,23 +243,10 @@ export function createSchemaField<
   })
 
   const SchemaFieldFactory = (type: SchemaTypes, name: string) => {
-    return defineComponent<
-      ISchemaMarkupFieldProps<
-        Components,
-        ComponentPath<Components>,
-        ComponentPath<Components>
-      >
-    >({
+    return defineComponent({
       name: name,
-      props: Object.assign({}, markupProps),
-      setup(
-        props: ISchemaMarkupFieldProps<
-          Components,
-          ComponentPath<Components>,
-          ComponentPath<Components>
-        >,
-        { slots }
-      ) {
+      props: [...markupProps],
+      setup(props: ISchemaTypeFieldProps, { slots }) {
         return () =>
           h(
             MarkupField,
@@ -348,5 +273,5 @@ export function createSchemaField<
     SchemaDateTimeField: SchemaFieldFactory('datetime', 'SchemaDatetimeField'),
     SchemaVoidField: SchemaFieldFactory('void', 'SchemaVoidField'),
     SchemaNumberField: SchemaFieldFactory('number', 'SchemaNumberField'),
-  } as any
+  } as SchemaFieldComponents
 }

--- a/packages/vue/src/components/VoidField.ts
+++ b/packages/vue/src/components/VoidField.ts
@@ -8,43 +8,27 @@ import { getRawComponent } from '../utils/getRawComponent'
 
 import type { IVoidFieldProps, DefineComponent } from '../types'
 
-export default defineComponent<IVoidFieldProps>({
+export default defineComponent({
   name: 'VoidField',
-  props: {
-    name: {},
-    title: {},
-    description: {},
-    basePath: {},
-    decorator: Array,
-    component: Array,
-    display: String,
-    pattern: String,
-    hidden: {
-      type: Boolean,
-      default: undefined,
-    },
-    visible: {
-      type: Boolean,
-      default: undefined,
-    },
-    editable: {
-      type: Boolean,
-      default: undefined,
-    },
-    disabled: {
-      type: Boolean,
-      default: undefined,
-    },
-    readOnly: {
-      type: Boolean,
-      default: undefined,
-    },
-    readPretty: {
-      type: Boolean,
-      default: undefined,
-    },
-    reactions: [Array, Function],
-  },
+  props: [
+    'name',
+    'basePath',
+    'title',
+    'description',
+    'display',
+    'pattern',
+    'hidden',
+    'visible',
+    'editable',
+    'disabled',
+    'readOnly',
+    'readPretty',
+    'decorator',
+    'component',
+    'reactions',
+    'content',
+    'data',
+  ],
   setup(props: IVoidFieldProps, { slots }) {
     const formRef = useForm()
     const parentRef = useField()
@@ -88,4 +72,4 @@ export default defineComponent<IVoidFieldProps>({
       return h(ReactiveField, componentData, children)
     }
   },
-}) as unknown as DefineComponent<IVoidFieldProps>
+}) as DefineComponent<IVoidFieldProps>

--- a/packages/vue/src/shared/connect.ts
+++ b/packages/vue/src/shared/connect.ts
@@ -1,4 +1,3 @@
-import { Vue2Component } from '../types/vue2'
 import { isVue2, markRaw, defineComponent } from 'vue-demi'
 import { isFn, isStr, FormPath, each } from '@formily/shared'
 import { isVoidField, GeneralField } from '@formily/core'
@@ -12,7 +11,6 @@ import type {
   IComponentMapper,
   IStateMapper,
   VueComponentProps,
-  DefineComponent,
 } from '../types'
 
 export function mapProps<T extends VueComponent = VueComponent>(
@@ -63,7 +61,7 @@ export function mapProps<T extends VueComponent = VueComponent>(
             )
           }
         },
-      }) as unknown as DefineComponent<VueComponentProps<T>>
+      })
     )
   }
 }
@@ -94,7 +92,7 @@ export function mapReadPretty<T extends VueComponent, C extends VueComponent>(
             )
           }
         },
-      }) as unknown as DefineComponent<VueComponentProps<T>>
+      })
     )
   }
 }
@@ -102,27 +100,27 @@ export function mapReadPretty<T extends VueComponent, C extends VueComponent>(
 export function connect<T extends VueComponent>(
   target: T,
   ...args: IComponentMapper[]
-) {
+): T {
   const Component = args.reduce((target: VueComponent, mapper) => {
     return mapper(target)
   }, target)
   /* istanbul ignore else */
   if (isVue2) {
-    const functionalComponent = {
+    const functionalComponent = defineComponent({
       functional: true,
       render(h, context) {
-        return h(Component as Vue2Component, context.data, context.children)
+        return h(Component, context.data, context.children)
       },
-    }
-    return markRaw(functionalComponent)
+    })
+    return markRaw(functionalComponent) as T
   } else {
     const functionalComponent = defineComponent({
-      setup(props: VueComponentProps<T>, { attrs, slots }) {
+      setup(props, { attrs, slots }) {
         return () => {
           return h(Component, { props, attrs }, slots)
         }
       },
     })
-    return markRaw(functionalComponent)
+    return markRaw(functionalComponent) as T
   }
 }

--- a/packages/vue/src/shared/fragment.ts
+++ b/packages/vue/src/shared/fragment.ts
@@ -1,16 +1,16 @@
 import frag from 'vue-frag'
-import { VueComponent } from '../types'
+import { DefineComponent } from '../types'
 import { isVue2, defineComponent } from 'vue-demi'
 
 export const Fragment = '#fragment'
 
-let FragmentComponent: VueComponent
+let FragmentComponent: DefineComponent<{}>
 
 if (isVue2) {
-  FragmentComponent = {
+  FragmentComponent = defineComponent({
     name: 'Fragment',
     directives: {
-      frag,
+      frag: frag as any,
     },
     render(h) {
       const vm = this as any
@@ -26,7 +26,7 @@ if (isVue2) {
         vm?.$scopedSlots?.default?.(vm.$attrs)
       )
     },
-  }
+  })
 } else {
   /* istanbul ignore next */
   FragmentComponent = defineComponent({

--- a/packages/vue/src/types/index.ts
+++ b/packages/vue/src/types/index.ts
@@ -1,5 +1,5 @@
-import type { Vue2Component } from './vue2'
-import type { Vue3Component } from './vue3'
+import { Component } from 'vue'
+import * as VueDemi from 'vue-demi'
 import {
   Form,
   IFieldFactoryProps,
@@ -13,18 +13,19 @@ import {
 } from '@formily/core'
 import type { FormPathPattern } from '@formily/shared'
 import type { ISchema, Schema, SchemaKey } from '@formily/json-schema'
-import type { DefineComponent as DefineVue3Component } from '@type-helper/vue3'
 
-export type DefineComponent<Props = Record<string, any>> =
-  DefineVue3Component<Props>
+class Helper<Props> {
+  Return = VueDemi.defineComponent({} as { props: Record<keyof Props, any> })
+}
 
-export type VueComponent<Props = Record<string, any>> =
-  | Vue2Component<Props>
-  | Vue3Component<Props>
-  | Props
+export type DefineComponent<Props> = Helper<Props>['Return']
+
+export type VueComponent = Component
+
 export type VueComponentOptionsWithProps = {
   props: unknown
 }
+
 export type VueComponentProps<T extends VueComponent> =
   T extends VueComponentOptionsWithProps ? T['props'] : T
 

--- a/packages/vue/src/types/vue2.ts
+++ b/packages/vue/src/types/vue2.ts
@@ -1,8 +1,0 @@
-import type { Component, ComponentOptions } from '@type-helper/vue2'
-export type Vue2ComponentOptions = ComponentOptions<never>
-export type Vue2Component<Props = Record<string, any>> = Component<
-  any,
-  any,
-  any,
-  Props
->

--- a/packages/vue/src/types/vue3.ts
+++ b/packages/vue/src/types/vue3.ts
@@ -1,3 +1,0 @@
-import type { Component, ComponentOptions } from '@type-helper/vue3'
-
-export { Component as Vue3Component, ComponentOptions as Vue3ComponentOptions }

--- a/packages/vue/tsconfig.types.json
+++ b/packages/vue/tsconfig.types.json
@@ -1,10 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./lib",
+    "outDir": "./type-artefacts",
     "paths": {
       "@formily/*": ["packages/*", "devtools/*"]
     },
-    "declaration": false
+    "declaration": true,
+    "sourceMap": false,
+    "inlineSources": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,10 +383,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.7", "@babel/parser@^7.15.0", "@babel/parser@^7.16.0", "@babel/parser@^7.16.3", "@babel/parser@^7.4.3":
+"@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.14.7", "@babel/parser@^7.16.0", "@babel/parser@^7.16.3", "@babel/parser@^7.4.3":
   version "7.16.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
   integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
+
+"@babel/parser@^7.16.4":
+  version "7.16.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.6.tgz#8f194828193e8fa79166f34a4b4e52f3e769a314"
+  integrity sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.2":
   version "7.16.2"
@@ -2717,22 +2722,6 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@type-helper/vue2@npm:vue@2", vue@^2.6.0, vue@^2.6.10, vue@^2.6.12:
-  version "2.6.14"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
-  integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
-
-"@type-helper/vue3@npm:vue@3":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.22.tgz#46e4dd89e98cc4b851ae1eb35f00ced413a34bb7"
-  integrity sha512-KD5nZpXVZquOC6926Xnp3zOvswrUyO9Rya7ZUoxWFQEjFDW4iACtwzubRB4Um2Om9kj6CaJOqAVRDSFlqLpdgw==
-  dependencies:
-    "@vue/compiler-dom" "3.2.22"
-    "@vue/compiler-sfc" "3.2.22"
-    "@vue/runtime-dom" "3.2.22"
-    "@vue/server-renderer" "3.2.22"
-    "@vue/shared" "3.2.22"
-
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
@@ -3508,47 +3497,47 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.2.1"
     camelcase "^5.0.0"
 
-"@vue/compiler-core@3.2.22":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.22.tgz#5e3d3b983cc7f430ddbc6a8773c872dcf410dc89"
-  integrity sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==
+"@vue/compiler-core@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.26.tgz#9ab92ae624da51f7b6064f4679c2d4564f437cc8"
+  integrity sha512-N5XNBobZbaASdzY9Lga2D9Lul5vdCIOXvUMd6ThcN8zgqQhPKfCV+wfAJNNJKQkSHudnYRO2gEB+lp0iN3g2Tw==
   dependencies:
-    "@babel/parser" "^7.15.0"
-    "@vue/shared" "3.2.22"
+    "@babel/parser" "^7.16.4"
+    "@vue/shared" "3.2.26"
     estree-walker "^2.0.2"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.2.22":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz#221cc358a6c0651c04e1dd22a8470b21e56ee1a5"
-  integrity sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==
+"@vue/compiler-dom@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.26.tgz#c7a7b55d50a7b7981dd44fc28211df1450482667"
+  integrity sha512-smBfaOW6mQDxcT3p9TKT6mE22vjxjJL50GFVJiI0chXYGU/xzC05QRGrW3HHVuJrmLTLx5zBhsZ2dIATERbarg==
   dependencies:
-    "@vue/compiler-core" "3.2.22"
-    "@vue/shared" "3.2.22"
+    "@vue/compiler-core" "3.2.26"
+    "@vue/shared" "3.2.26"
 
-"@vue/compiler-sfc@3.2.22":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.22.tgz#ffd0e5e35479b6ade18d12fefec369cbaf2f7718"
-  integrity sha512-tWRQ5ge1tsTDhUwHgueicKJ8rYm6WUVAPTaIpFW3GSwZKcOEJ2rXdfkHFShNVGupeRALz2ET2H84OL0GeRxY0A==
+"@vue/compiler-sfc@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.26.tgz#3ce76677e4aa58311655a3bea9eb1cb804d2273f"
+  integrity sha512-ePpnfktV90UcLdsDQUh2JdiTuhV0Skv2iYXxfNMOK/F3Q+2BO0AulcVcfoksOpTJGmhhfosWfMyEaEf0UaWpIw==
   dependencies:
-    "@babel/parser" "^7.15.0"
-    "@vue/compiler-core" "3.2.22"
-    "@vue/compiler-dom" "3.2.22"
-    "@vue/compiler-ssr" "3.2.22"
-    "@vue/ref-transform" "3.2.22"
-    "@vue/shared" "3.2.22"
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.26"
+    "@vue/compiler-dom" "3.2.26"
+    "@vue/compiler-ssr" "3.2.26"
+    "@vue/reactivity-transform" "3.2.26"
+    "@vue/shared" "3.2.26"
     estree-walker "^2.0.2"
     magic-string "^0.25.7"
     postcss "^8.1.10"
     source-map "^0.6.1"
 
-"@vue/compiler-ssr@3.2.22":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.22.tgz#23552c31b76b45baf5f244713c81d77ab59447d2"
-  integrity sha512-Cl6aoLJtXzzBkk1sKod8S0WBJLts3+ugVC91d22gGpbkw/64WnF12tOZi7Rg54PPLi1NovqyNWPsLH/SAFcu+w==
+"@vue/compiler-ssr@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.26.tgz#fd049523341fbf4ab5e88e25eef566d862894ba7"
+  integrity sha512-2mywLX0ODc4Zn8qBoA2PDCsLEZfpUGZcyoFRLSOjyGGK6wDy2/5kyDOWtf0S0UvtoyVq95OTSGIALjZ4k2q/ag==
   dependencies:
-    "@vue/compiler-dom" "3.2.22"
-    "@vue/shared" "3.2.22"
+    "@vue/compiler-dom" "3.2.26"
+    "@vue/shared" "3.2.26"
 
 "@vue/component-compiler-utils@^3.1.0":
   version "3.3.0"
@@ -3573,53 +3562,65 @@
   dependencies:
     tslib "^2.3.1"
 
-"@vue/reactivity@3.2.22", "@vue/reactivity@^3.0.11":
+"@vue/reactivity-transform@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity-transform/-/reactivity-transform-3.2.26.tgz#6d8f20a4aa2d19728f25de99962addbe7c4d03e9"
+  integrity sha512-XKMyuCmzNA7nvFlYhdKwD78rcnmPb7q46uoR00zkX6yZrUmcCQ5OikiwUEVbvNhL5hBJuvbSO95jB5zkUon+eQ==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.26"
+    "@vue/shared" "3.2.26"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+
+"@vue/reactivity@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.26.tgz#d529191e581521c3c12e29ef986d4c8a933a0f83"
+  integrity sha512-h38bxCZLW6oFJVDlCcAiUKFnXI8xP8d+eO0pcDxx+7dQfSPje2AO6M9S9QO6MrxQB7fGP0DH0dYQ8ksf6hrXKQ==
+  dependencies:
+    "@vue/shared" "3.2.26"
+
+"@vue/reactivity@^3.0.11":
   version "3.2.22"
   resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.22.tgz#88655c0b4febc561136e6550e329039f860caa0a"
   integrity sha512-xNkLAItjI0xB+lFeDgKCrSItmrHTaAzSnt8LmdSCPQnDyarmzbi/u4ESQnckWvlL7lSRKiEaOvblaNyqAa7OnQ==
   dependencies:
     "@vue/shared" "3.2.22"
 
-"@vue/ref-transform@3.2.22":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/@vue/ref-transform/-/ref-transform-3.2.22.tgz#16b03994eac71528cceff4cf76178ed9b44ac90a"
-  integrity sha512-qalVWbq5xWWxLZ0L9OroBg/JZhzavQuCcDXblfErxyDEH6Xc5gIJ4feo1SVCICFzhAUgLgQTdSFLpgjBawbFpw==
+"@vue/runtime-core@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.26.tgz#5c59cc440ed7a39b6dbd4c02e2d21c8d1988f0de"
+  integrity sha512-BcYi7qZ9Nn+CJDJrHQ6Zsmxei2hDW0L6AB4vPvUQGBm2fZyC0GXd/4nVbyA2ubmuhctD5RbYY8L+5GUJszv9mQ==
   dependencies:
-    "@babel/parser" "^7.15.0"
-    "@vue/compiler-core" "3.2.22"
-    "@vue/shared" "3.2.22"
-    estree-walker "^2.0.2"
-    magic-string "^0.25.7"
+    "@vue/reactivity" "3.2.26"
+    "@vue/shared" "3.2.26"
 
-"@vue/runtime-core@3.2.22":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.22.tgz#111f1bc97f20249e05ca2189856d99c82d72de32"
-  integrity sha512-e7WOC55wmHPvmoVUk9VBe/Z9k5bJfWJfVIlkUkiADJn0bOgQD29oh/GS14Kb3aEJXIHLI17Em6+HxNut1sIh7Q==
+"@vue/runtime-dom@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.26.tgz#84d3ae2584488747717c2e072d5d9112c0d2e6c2"
+  integrity sha512-dY56UIiZI+gjc4e8JQBwAifljyexfVCkIAu/WX8snh8vSOt/gMSEGwPRcl2UpYpBYeyExV8WCbgvwWRNt9cHhQ==
   dependencies:
-    "@vue/reactivity" "3.2.22"
-    "@vue/shared" "3.2.22"
-
-"@vue/runtime-dom@3.2.22":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.22.tgz#c11d75dd51375ee4c74e339f6523ca05e37faa37"
-  integrity sha512-w7VHYJoliLRTLc5beN77wxuOjla4v9wr2FF22xpZFYBmH4U1V7HkYhoHc1BTuNghI15CXT1tNIMhibI1nrQgdw==
-  dependencies:
-    "@vue/runtime-core" "3.2.22"
-    "@vue/shared" "3.2.22"
+    "@vue/runtime-core" "3.2.26"
+    "@vue/shared" "3.2.26"
     csstype "^2.6.8"
 
-"@vue/server-renderer@3.2.22":
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.2.22.tgz#049c91a495cb0fcdac02dec485c31cb99410885f"
-  integrity sha512-jCwbQgKPXiXoH9VS9F7K+gyEvEMrjutannwEZD1R8fQ9szmOTqC+RRbIY3Uf2ibQjZtZ8DV9a4FjxICvd9zZlQ==
+"@vue/server-renderer@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.2.26.tgz#f16a4b9fbcc917417b4cea70c99afce2701341cf"
+  integrity sha512-Jp5SggDUvvUYSBIvYEhy76t4nr1vapY/FIFloWmQzn7UxqaHrrBpbxrqPcTrSgGrcaglj0VBp22BKJNre4aA1w==
   dependencies:
-    "@vue/compiler-ssr" "3.2.22"
-    "@vue/shared" "3.2.22"
+    "@vue/compiler-ssr" "3.2.26"
+    "@vue/shared" "3.2.26"
 
 "@vue/shared@3.2.22":
   version "3.2.22"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.22.tgz#26dcbe5e530f6c1f2de5ca9aeab92ab00f523b41"
   integrity sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ==
+
+"@vue/shared@3.2.26":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.26.tgz#7acd1621783571b9a82eca1f041b4a0a983481d9"
+  integrity sha512-vPV6Cq+NIWbH5pZu+V+2QHE9y1qfuTq49uNWw4f7FDEeZaDU2H2cx5jcUZOAKW7qTrUS4k6qZPbMy1x4N96nbA==
 
 "@vue/test-utils@1.0.0-beta.22":
   version "1.0.0-beta.22"
@@ -19835,6 +19836,22 @@ vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+
+"vue3@npm:vue@3":
+  version "3.2.26"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.26.tgz#5db575583ecae495c7caa5c12fd590dffcbb763e"
+  integrity sha512-KD4lULmskL5cCsEkfhERVRIOEDrfEL9CwAsLYpzptOGjaGFNWo3BQ9g8MAb7RaIO71rmVOziZ/uEN/rHwcUIhg==
+  dependencies:
+    "@vue/compiler-dom" "3.2.26"
+    "@vue/compiler-sfc" "3.2.26"
+    "@vue/runtime-dom" "3.2.26"
+    "@vue/server-renderer" "3.2.26"
+    "@vue/shared" "3.2.26"
+
+vue@^2.6.0, vue@^2.6.10, vue@^2.6.12:
+  version "2.6.14"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
+  integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
 
 vuepress-html-webpack-plugin@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://github.com/alibaba/formily/blob/formily_next/.github/GIT_COMMIT_SPECIFIC.md) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [ ] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

- Add auto switching for types of @formily/vue in postinstall hook.
- Add `formily-vue-fix` & `formily-vue-switch` command. (Just like [vue-demi](https://github.com/vueuse/vue-demi) does)
- Removed dependencies of `@type-helper/vue2` & `@type-helper/vue3` which may cause type confusion.
- Exports of `Vue2Components` may be deprecated.
