### PR TITLE
feat(vue): support x-slot

### DIFF
--- a/packages/vue/src/__tests__/schema.json.spec.ts
+++ b/packages/vue/src/__tests__/schema.json.spec.ts
@@ -785,6 +785,139 @@ describe('x-content', () => {
     expect(queryByTestId('previewer5')).toBeVisible()
     expect(queryByTestId('previewer5').textContent).toEqual('123')
   })
+
+  test('wrong x-content will be ignore', () => {
+    const form = createForm()
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer,
+      },
+    })
+    const { queryAllByTestId, container } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'object',
+            properties: {
+              input1: {
+                type: 'string',
+                'x-component': 'Previewer',
+                'x-content': {
+                  default: {
+                    someAttr: '123',
+                  },
+                },
+              },
+              input2: {
+                type: 'string',
+                'x-component': 'Previewer',
+                'x-content': {
+                  default: null,
+                },
+              },
+            },
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    queryAllByTestId('previewer').forEach((el) => expect(el).toBeVisible())
+    queryAllByTestId('previewer').forEach((el) =>
+      expect(el.textContent).toEqual('')
+    )
+  })
+})
+
+describe('x-slot', () => {
+  test('x-slot works in void field properties', () => {
+    const form = createForm()
+    const Content = {
+      render(h) {
+        return h('span', '123')
+      },
+    }
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer4,
+        Content,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'void',
+            'x-component': 'Previewer4',
+            properties: {
+              content: {
+                type: 'void',
+                'x-component': 'Content',
+                'x-slot': 'content',
+              },
+            },
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer4')).toBeVisible()
+    expect(queryByTestId('previewer4').textContent).toEqual('123')
+  })
+  test('x-slot works in object field properties', () => {
+    const form = createForm()
+    const Content = {
+      render(h) {
+        return h('span', '123')
+      },
+    }
+    const { SchemaField } = createSchemaField({
+      components: {
+        Previewer4,
+        Content,
+      },
+    })
+    const { queryByTestId } = render({
+      components: { SchemaField },
+      data() {
+        return {
+          form,
+          schema: new Schema({
+            type: 'object',
+            'x-component': 'Previewer4',
+            properties: {
+              content: {
+                type: 'void',
+                'x-component': 'Content',
+                'x-slot': 'content',
+              },
+            },
+          }),
+        }
+      },
+      template: `<FormProvider :form="form">
+        <SchemaField
+          name="string"
+          :schema="schema"
+        />
+      </FormProvider>`,
+    })
+    expect(queryByTestId('previewer4')).toBeVisible()
+    expect(queryByTestId('previewer4').textContent).toEqual('123')
+  })
 })
 
 describe('scope', () => {

--- a/packages/vue/src/__tests__/schema.markup.spec.ts
+++ b/packages/vue/src/__tests__/schema.markup.spec.ts
@@ -332,7 +332,15 @@ describe('recursion field', () => {
         const schemaRef = useFieldSchema()
         return () => {
           return h('div', { attrs: { 'data-testid': 'object' } }, [
-            h('RecursionField', { props: { schema: schemaRef.value } }),
+            h('RecursionField', {
+              props: {
+                schema: schemaRef.value,
+                mapProperties: (schema) => {
+                  schema.default = '123'
+                  return schema
+                },
+              },
+            }),
           ])
         }
       },
@@ -340,18 +348,16 @@ describe('recursion field', () => {
 
     const CustomObject2 = defineComponent({
       setup() {
-        const fieldRef = useField()
         const schemaRef = useFieldSchema()
         return () => {
           const schema = schemaRef.value
-          const field = fieldRef.value
-          return h('div', { attrs: { 'data-testid': 'only-properties' } }, [
+          return h('div', { attrs: { 'data-testid': 'object' } }, [
             h('RecursionField', {
               props: {
-                name: schema.name,
-                basePath: field.address,
                 schema,
-                onlyRenderProperties: true,
+                mapProperties: () => {
+                  return null
+                },
               },
             }),
           ])
@@ -382,15 +388,12 @@ describe('recursion field', () => {
           <SchemaObjectField x-component="CustomObject2">
             <SchemaStringField x-component="Input" />
           </SchemaObjectField>
-          <SchemaVoidField x-component="CustomObject2">
-            <SchemaStringField x-component="Input" />
-          </SchemaVoidField>
         </SchemaField>
       </FormProvider>`,
     })
-    expect(queryAllByTestId('input').length).toEqual(3)
-    expect(queryAllByTestId('object').length).toEqual(1)
-    expect(queryAllByTestId('only-properties').length).toEqual(2)
+    expect(queryAllByTestId('input').length).toEqual(2)
+    expect(queryAllByTestId('input')[0].getAttribute('value')).toEqual('123')
+    expect(queryAllByTestId('input')[1].getAttribute('value')).toBeFalsy()
   })
 
   test('filterProperties', () => {

--- a/packages/vue/src/components/ArrayField.ts
+++ b/packages/vue/src/components/ArrayField.ts
@@ -42,9 +42,8 @@ if (isVue2) {
             ...props,
             ...getRawComponent(props),
           },
-        } as any
-        const slots = context.slots as any
-        return _h(ReactiveField, componentData, slots)
+        } as Record<string, unknown>
+        return _h(ReactiveField, componentData, context.slots)
       }
     },
   } as unknown as DefineComponent<IArrayFieldProps>

--- a/packages/vue/src/components/Field.ts
+++ b/packages/vue/src/components/Field.ts
@@ -40,9 +40,8 @@ if (isVue2) {
             ...props,
             ...getRawComponent(props),
           },
-        } as any
-        const slots = context.slots as any
-        return _h(ReactiveField, componentData, slots)
+        } as Record<string, unknown>
+        return _h(ReactiveField, componentData, context.slots)
       }
     },
   } as unknown as DefineComponent<IFieldProps>

--- a/packages/vue/src/components/ObjectField.ts
+++ b/packages/vue/src/components/ObjectField.ts
@@ -42,9 +42,8 @@ if (isVue2) {
             ...props,
             ...getRawComponent(props),
           },
-        } as any
-        const slots = context.slots as any
-        return _h(ReactiveField, componentData, slots)
+        } as Record<string, unknown>
+        return _h(ReactiveField, componentData, context.slots)
       }
     },
   } as unknown as DefineComponent<IObjectFieldProps>

--- a/packages/vue/src/components/VoidField.ts
+++ b/packages/vue/src/components/VoidField.ts
@@ -42,9 +42,8 @@ if (isVue2) {
             ...props,
             ...getRawComponent(props),
           },
-        } as any
-        const slots = context.slots as any
-        return _h(ReactiveField, componentData, slots)
+        } as Record<string, unknown>
+        return _h(ReactiveField, componentData, context.slots)
       }
     },
   } as unknown as DefineComponent<IVoidFieldProps>


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [ ] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

Support 'x-slot' in RecursionField. This feature provides [Slots](https://v2.vuejs.org/v2/guide/components-slots.html) for object/void type field's component.