### PR TITLE
fix(antd/next): form step setcurrent bug

### DIFF
--- a/packages/antd/src/form-step/index.tsx
+++ b/packages/antd/src/form-step/index.tsx
@@ -89,14 +89,12 @@ const createFormStep = (defaultCurrent = 0): IFormStep => {
 
   const next = action.bound(() => {
     if (formStep.allowNext) {
-      setDisplay(formStep.current + 1)
       formStep.setCurrent(formStep.current + 1)
     }
   })
 
   const back = action.bound(() => {
     if (formStep.allowBack) {
-      setDisplay(formStep.current - 1)
       formStep.setCurrent(formStep.current - 1)
     }
   })
@@ -109,6 +107,7 @@ const createFormStep = (defaultCurrent = 0): IFormStep => {
     },
     current: defaultCurrent,
     setCurrent(key: number) {
+      setDisplay(key)
       formStep.current = key
     },
     get allowNext() {

--- a/packages/next/src/form-step/index.tsx
+++ b/packages/next/src/form-step/index.tsx
@@ -92,14 +92,12 @@ const createFormStep = (defaultCurrent = 0): IFormStep => {
 
   const next = () => {
     if (formStep.allowNext) {
-      setDisplay(formStep.current + 1)
       formStep.setCurrent(formStep.current + 1)
     }
   }
 
   const back = () => {
     if (formStep.allowBack) {
-      setDisplay(formStep.current - 1)
       formStep.setCurrent(formStep.current - 1)
     }
   }
@@ -112,6 +110,7 @@ const createFormStep = (defaultCurrent = 0): IFormStep => {
     },
     current: defaultCurrent,
     setCurrent(key: number) {
+      setDisplay(key)
       formStep.current = key
     },
     get allowNext() {


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?
当前调用`formStep.setCurrent(1)` 时，因为没有调`setDisplay`, 导致跳到那一步了，但是域都没显示出来，依然是hidden状态

