### PR TITLE
fix(docs): export static guide routes (fix #4322)

### DIFF
--- a/.umirc.js
+++ b/.umirc.js
@@ -6,6 +6,7 @@ export default {
   favicon:
     '//img.alicdn.com/imgextra/i3/O1CN01XtT3Tv1Wd1b5hNVKy_!!6000000002810-55-tps-360-360.svg',
   outputPath: './doc-site',
+  exportStatic: {},
   locales: [
     ['en-US', 'English'],
     ['zh-CN', '中文'],


### PR DESCRIPTION
_Before_ submitting a pull request, please make sure the following is done...

- [x] Ensure the pull request title and commit message follow the [Commit Specific](https://formilyjs.org/guide/contribution#pr-specification) in **English**.
- [x] Fork the repo and create your branch from `master` or `formily_next`.
- [x] If you've added code that should be tested, add tests!
- [x] If you've changed APIs, update the documentation.
- [x] Ensure the test suite passes (`npm test`).
- [x] Make sure your code lints (`npm run lint`) - we've done our best to make sure these rules match our internal linting guidelines.

**Please do not delete the above content**

---

## What have you changed?

Fixes #4322.

The deployed documentation site currently emits only the root `index.html` and `404.html`. As a result, Netlify returns HTTP 404 for valid direct links such as `/guide/scenes/tab-form`. The client-side router can render the page from the 404 shell after JavaScript loads, but the response remains incorrect for link checkers, crawlers, and clients where JavaScript does not run.

Enable Umi 3's `exportStatic` option so Dumi emits an `index.html` for every known documentation and demo route. This fixes valid direct links without a catch-all rewrite, so unknown paths still return 404.

### Verification

- `yarn build:docs`: 210 HTML files emitted; the English and Chinese tab-form routes are generated.
- Local static server:
  - `/guide/scenes/tab-form/` returns 200.
  - `/zh-CN/guide/scenes/tab-form/` returns 200.
  - `/not-a-real-route` returns 404.
- `yarn lint`: 0 errors (one pre-existing warning).
- `yarn build`: all 14 workspace packages pass.
- `yarn test:prod --runInBand`: 60 suites, 716 tests, and 7 snapshots pass.
- `git diff --check` passes.
